### PR TITLE
revert(cloudfront): stop forwarding Host to restore site

### DIFF
--- a/aws/global/cloudfront/tellerstech-website.tf
+++ b/aws/global/cloudfront/tellerstech-website.tf
@@ -80,7 +80,6 @@ resource "aws_cloudfront_origin_request_policy" "wordpress" {
     header_behavior = "whitelist"
     headers {
       items = [
-        "Host",
         "CloudFront-Forwarded-Proto",
         "CloudFront-Is-Desktop-Viewer",
         "CloudFront-Is-Mobile-Viewer",
@@ -151,7 +150,7 @@ resource "aws_cloudfront_distribution" "tellerstech_website" {
     origin_request_policy_id = aws_cloudfront_origin_request_policy.wordpress.id
   }
 
-  # wp-admin - no caching, forward Host so origin gets www.tellerstech.com
+  # wp-admin - no caching (AllViewer: origin gets Host origin.tellerstech.com)
   ordered_cache_behavior {
     path_pattern             = "/wp-admin/*"
     allowed_methods          = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
@@ -160,10 +159,10 @@ resource "aws_cloudfront_distribution" "tellerstech_website" {
     viewer_protocol_policy   = "redirect-to-https"
     compress                 = true
     cache_policy_id          = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" # AWS Managed CachingDisabled
-    origin_request_policy_id = aws_cloudfront_origin_request_policy.wordpress.id
+    origin_request_policy_id = "216adef6-5c7f-47e4-b989-5492eafa07d3" # AWS Managed AllViewer
   }
 
-  # wp-login.php - no caching, forward Host so origin gets www.tellerstech.com
+  # wp-login.php - no caching
   ordered_cache_behavior {
     path_pattern             = "/wp-login.php"
     allowed_methods          = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
@@ -172,7 +171,7 @@ resource "aws_cloudfront_distribution" "tellerstech_website" {
     viewer_protocol_policy   = "redirect-to-https"
     compress                 = true
     cache_policy_id          = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" # AWS Managed CachingDisabled
-    origin_request_policy_id = aws_cloudfront_origin_request_policy.wordpress.id
+    origin_request_policy_id = "216adef6-5c7f-47e4-b989-5492eafa07d3" # AWS Managed AllViewer
   }
 
   # wp-json API - no caching
@@ -184,7 +183,7 @@ resource "aws_cloudfront_distribution" "tellerstech_website" {
     viewer_protocol_policy   = "redirect-to-https"
     compress                 = true
     cache_policy_id          = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" # AWS Managed CachingDisabled
-    origin_request_policy_id = aws_cloudfront_origin_request_policy.wordpress.id
+    origin_request_policy_id = "216adef6-5c7f-47e4-b989-5492eafa07d3" # AWS Managed AllViewer
   }
 
   # wp-cron.php - no caching
@@ -196,7 +195,7 @@ resource "aws_cloudfront_distribution" "tellerstech_website" {
     viewer_protocol_policy   = "redirect-to-https"
     compress                 = true
     cache_policy_id          = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" # AWS Managed CachingDisabled
-    origin_request_policy_id = aws_cloudfront_origin_request_policy.wordpress.id
+    origin_request_policy_id = "216adef6-5c7f-47e4-b989-5492eafa07d3" # AWS Managed AllViewer
   }
 
   # RSS/Atom feeds - no caching (must always be fresh for podcast apps)
@@ -208,7 +207,7 @@ resource "aws_cloudfront_distribution" "tellerstech_website" {
     viewer_protocol_policy   = "redirect-to-https"
     compress                 = true
     cache_policy_id          = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" # AWS Managed CachingDisabled
-    origin_request_policy_id = aws_cloudfront_origin_request_policy.wordpress.id
+    origin_request_policy_id = "216adef6-5c7f-47e4-b989-5492eafa07d3" # AWS Managed AllViewer
   }
 
   # Root feed endpoint - no caching
@@ -220,7 +219,7 @@ resource "aws_cloudfront_distribution" "tellerstech_website" {
     viewer_protocol_policy   = "redirect-to-https"
     compress                 = true
     cache_policy_id          = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" # AWS Managed CachingDisabled
-    origin_request_policy_id = aws_cloudfront_origin_request_policy.wordpress.id
+    origin_request_policy_id = "216adef6-5c7f-47e4-b989-5492eafa07d3" # AWS Managed AllViewer
   }
 
   # Sitemaps - short cache (2 hour default like WordPress pages)


### PR DESCRIPTION
## Urgent: site 502 again

With Host forwarding (PR #49) deployed, the main site returns 502. Origin returns 200 when curled with Host: www.tellerstech.com, but CloudFront gets 502 when it connects. Reverting so CloudFront sends Host: origin.tellerstech.com again and the site is back up.

- Remove Host from WordPress origin request policy
- Use AllViewer for wp-admin, wp-login, wp-json, wp-cron, feed paths

**After merge:** Main site works. wp-admin will still 502. The CloudFront→origin 502 when Host: www is sent (despite origin responding 200 to curl) remains to be debugged separately.