### PR TITLE
fix(cloudfront): forward X-WP-Nonce header to origin for REST API auth

### DIFF
--- a/aws/global/cloudfront/tellerstech-website.tf
+++ b/aws/global/cloudfront/tellerstech-website.tf
@@ -80,6 +80,7 @@ resource "aws_cloudfront_origin_request_policy" "wordpress" {
     header_behavior = "whitelist"
     headers {
       items = [
+        "X-WP-Nonce",
         "CloudFront-Forwarded-Proto",
         "CloudFront-Is-Desktop-Viewer",
         "CloudFront-Is-Mobile-Viewer",


### PR DESCRIPTION
## Summary
Fixes "Sorry, you are not allowed to edit this post" and Yoast "not allowed to do that" errors when using wp-admin through CloudFront.

## Cause
WordPress block editor and Yoast send `X-WP-Nonce` header in REST API requests (`/wp-json/*`) for authentication. The origin request policy was only forwarding CloudFront-* headers, so the nonce was stripped before reaching the origin. Without it, WordPress rejects all write operations.

## Fix
Add `X-WP-Nonce` to the WordPress origin request policy headers whitelist.

## After merge
TFC applies. Wait for distribution to deploy (~5-10 min), then test editing a post in wp-admin and the Yoast setup wizard.