### PR TITLE
feat(cloudfront): forward CloudFront-Viewer-Address to WordPress origin

### DIFF
--- a/aws/global/cloudfront/tellerstech-website.tf
+++ b/aws/global/cloudfront/tellerstech-website.tf
@@ -85,6 +85,11 @@ resource "aws_cloudfront_origin_request_policy" "wordpress" {
         "CloudFront-Is-Desktop-Viewer",
         "CloudFront-Is-Mobile-Viewer",
         "CloudFront-Is-Tablet-Viewer",
+        # Real viewer "<ip>:<port>", set by CloudFront (un-spoofable). Lets the
+        # origin log the actual subscriber IP instead of the CDN edge IP. Read by
+        # ocb_client_ip() in tellerstech-ocb-subscribers.php. Forwarded only (not
+        # in the cache key), so it does not fragment the cache.
+        "CloudFront-Viewer-Address",
       ]
     }
   }


### PR DESCRIPTION
## Why
Subscriber IPs logged by WordPress (On Call Brief opt-in) show CloudFront edge IPs (`15.158.x`, `18.68.x`) instead of real visitors, because the origin only sees the client through `X-Forwarded-For` and the origin proxy appends the CDN edge IP as the last entry.

## Change
Add `CloudFront-Viewer-Address` to the `WordPress-OriginRequestPolicy` header whitelist in `aws/global/cloudfront/tellerstech-website.tf`. CloudFront then sends the real viewer `<ip>:<port>` to the origin (it sets/overwrites this header, so it can't be spoofed).

- Forwarded-only header (origin request policy), **not** part of the cache key — no cache fragmentation.
- Consumed by `ocb_client_ip()` in the website repo (companion PR TellersTechOrg/tellerstech-website#762).

## Apply notes
`terraform plan` should show an in-place update to `aws_cloudfront_origin_request_policy.wordpress` (adds one header item). Expect a CloudFront distribution propagation after apply.

## Test plan
- [x] `terraform fmt -check`
- [ ] `terraform plan` reviewed (in-place policy update only)
- [ ] After apply + propagation: a new OCB signup logs the real visitor IP in wp-admin

Made with [Cursor](https://cursor.com)