### PR TITLE
chore(ec2): keep primary WordPress instance on unlimited CPU credits

### DIFF
--- a/aws/us-east-1/ec2/primary-instance.tf
+++ b/aws/us-east-1/ec2/primary-instance.tf
@@ -13,7 +13,9 @@ resource "aws_instance" "primary" {
   associate_public_ip_address = true
 
   credit_specification {
-    cpu_credits = "standard"
+    # Keep "unlimited" so the WordPress server can burst without throttling.
+    # Matches the live instance; "standard" here would downgrade it on apply.
+    cpu_credits = "unlimited"
   }
 
   root_block_device {


### PR DESCRIPTION
## Why
`terraform plan` shows the primary WordPress instance (`i-0572702f0a58f6dcd`) drifting:

```
~ credit_specification {
    ~ cpu_credits = "unlimited" -> "standard"
  }
```

The live instance runs **unlimited**, but the config hardcoded **standard**, so the next `apply` would downgrade it and throttle the site under burst load. We want to keep unlimited.

## Change
Set `cpu_credits = "unlimited"` in `aws/us-east-1/ec2/primary-instance.tf`. After this, the plan is a no-op for this resource.

## Scope
Only the **primary** instance is touched. The secondary instance and both launch templates aren't in the plan (their `standard` config already matches live state), so they're intentionally left unchanged to avoid an unrequested cost increase.

## Heads-up
This reverses the recommendation in `aws/docs/cost-optimization-checklist.md` (which suggested `standard`). Left that doc as-is for now — say the word if you want it updated to reflect keeping unlimited.

## Test plan
- [x] `terraform fmt -check`
- [ ] `terraform plan` shows no change for `aws_instance.primary` credit_specification

Made with [Cursor](https://cursor.com)