### PR TITLE
fix(cloudfront): forward real User-Agent to WordPress origin

### DIFF
--- a/aws/global/cloudfront/tellerstech-website.tf
+++ b/aws/global/cloudfront/tellerstech-website.tf
@@ -90,6 +90,14 @@ resource "aws_cloudfront_origin_request_policy" "wordpress" {
         # ocb_client_ip() in tellerstech-ocb-subscribers.php. Forwarded only (not
         # in the cache key), so it does not fragment the cache.
         "CloudFront-Viewer-Address",
+        # Real viewer User-Agent. Without this, CloudFront forwards the literal
+        # "Amazon CloudFront" to the origin, so the newsletter click/open tracking
+        # (/{list}-click, /{list}-open) logged every device/OS/browser as
+        # Desktop/Other/Other in the analytics dashboard. Parsed by tt_ua_parse()
+        # in tellerstech-ocb-analytics.php. Forwarded via the ORIGIN REQUEST policy
+        # only (not the cache policy), so it does NOT become part of the cache key
+        # and does not fragment the page cache.
+        "User-Agent",
       ]
     }
   }


### PR DESCRIPTION
## Problem
The tellerstech.com newsletter analytics dashboard showed **Device = Desktop, OS = Other, Browser = Other** for 100% of traffic. A raw-UA diagnostic confirmed every logged click/open had the user-agent literal:

```
Count  Device   OS     Browser  User agent
10     Desktop  Other  Other    Amazon CloudFront
```

CloudFront only forwards `User-Agent` to the origin if it's in the cache or origin-request policy. `WordPress-OriginRequestPolicy` forwards `CloudFront-Viewer-Address` (so real IP/geo works) but **not** `User-Agent`, so CloudFront substitutes the literal `Amazon CloudFront`. The newsletter click/open tracking endpoints (`/{list}-click`, `/{list}-open`) run through the **default** cache behavior, which uses this policy — so the real subscriber UA never reached WordPress.

## Fix
Add `User-Agent` to `aws_cloudfront_origin_request_policy.wordpress`.

- It's in the **origin request policy**, not the cache policy, so the real viewer UA is forwarded to the origin **without** entering the cache key → the page cache is **not** fragmented per-UA. Same pattern already used for `CloudFront-Viewer-Address`.
- Affects every behavior using this policy (default + wp-admin/wp-login/wp-json/wp-cron/feed). Harmless for those — the origin already expects a UA.

## Plan / blast radius
- `terraform plan` should show an in-place update to `aws_cloudfront_origin_request_policy.wordpress` (add one header), and the distribution picking up the new policy version. No origin/cert/cache-key changes.
- After apply + CloudFront propagation, the analytics Device/OS/Browser charts will populate from real clicks (corporate link-scanner traffic will still show as the new "Link scanner" bucket — expected).

## Test plan
- [ ] `terraform plan` in `aws/` — confirm only the origin-request-policy header addition + distribution update
- [ ] `terraform apply`
- [ ] Send a test newsletter, click a tracked link, confirm the analytics "Raw user agents" diagnostic now shows a real browser UA instead of `Amazon CloudFront`

Made with [Cursor](https://cursor.com)