### PR TITLE
feat(ses): wire bounce/complaint feedback to SNS webhook

### DIFF
--- a/aws/global/ses/feedback-notifications.tf
+++ b/aws/global/ses/feedback-notifications.tf
@@ -1,0 +1,81 @@
+# SES Bounce/Complaint Feedback Loop
+#
+# Wires SES bounce + complaint feedback for the tellerstech.com sending
+# identity to an SNS topic, then delivers those notifications to the site's
+# webhook so it can suppress bad addresses and surface counts in the OCB/SIW
+# admin dashboards.
+#
+# Flow:
+#   SES (Bounce|Complaint) -> SNS topic -> HTTPS subscription -> WP webhook
+#
+# The webhook (tt_sub_handle_sns) verifies the SNS signature, auto-confirms
+# the subscription handshake, and applies suppression globally by email, so a
+# single subscription covers every list (OCB + SIW).
+#
+# Note: the SES domain identity (tellerstech.com) is provisioned outside this
+# repo, so it is referenced by name via var.ses_identity rather than as a
+# managed resource. data.aws_caller_identity.current is declared in
+# email-forwarding.tf and reused here.
+
+resource "aws_sns_topic" "ses_feedback" {
+  name = "tellerstech-ses-notifications"
+
+  tags = merge(
+    var.core_tags,
+    {
+      "Name"     = "TellersTech SES Bounce/Complaint Notifications"
+      "scm:file" = "aws/global/ses/feedback-notifications.tf"
+    },
+  )
+}
+
+# Allow SES (from this account only) to publish feedback to the topic.
+resource "aws_sns_topic_policy" "ses_feedback" {
+  arn = aws_sns_topic.ses_feedback.arn
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowSESPublish"
+        Effect = "Allow"
+        Principal = {
+          Service = "ses.amazonaws.com"
+        }
+        Action   = "sns:Publish"
+        Resource = aws_sns_topic.ses_feedback.arn
+        Condition = {
+          StringEquals = {
+            "AWS:SourceAccount" = data.aws_caller_identity.current.account_id
+          }
+        }
+      }
+    ]
+  })
+}
+
+# Deliver notifications to the site webhook. The endpoint auto-confirms the
+# SNS subscription handshake, so this becomes "Confirmed" without manual steps.
+resource "aws_sns_topic_subscription" "ses_feedback_webhook" {
+  topic_arn              = aws_sns_topic.ses_feedback.arn
+  protocol               = "https"
+  endpoint               = var.ses_feedback_endpoint
+  endpoint_auto_confirms = true
+  raw_message_delivery   = false
+}
+
+# Point the SES identity's Complaint + Bounce feedback at the SNS topic.
+# include_original_headers lets the webhook attribute events more precisely.
+resource "aws_ses_identity_notification_topic" "complaint" {
+  identity                 = var.ses_identity
+  notification_type        = "Complaint"
+  topic_arn                = aws_sns_topic.ses_feedback.arn
+  include_original_headers = true
+}
+
+resource "aws_ses_identity_notification_topic" "bounce" {
+  identity                 = var.ses_identity
+  notification_type        = "Bounce"
+  topic_arn                = aws_sns_topic.ses_feedback.arn
+  include_original_headers = true
+}

--- a/aws/global/ses/outputs.tf
+++ b/aws/global/ses/outputs.tf
@@ -7,3 +7,13 @@ output "email_forwarding_topic_name" {
   description = "Name of the email forwarding SNS topic"
   value       = aws_sns_topic.email_forwarding.name
 }
+
+output "ses_feedback_topic_arn" {
+  description = "ARN of the SES bounce/complaint feedback SNS topic"
+  value       = aws_sns_topic.ses_feedback.arn
+}
+
+output "ses_feedback_topic_name" {
+  description = "Name of the SES bounce/complaint feedback SNS topic"
+  value       = aws_sns_topic.ses_feedback.name
+}

--- a/aws/global/ses/variables.tf
+++ b/aws/global/ses/variables.tf
@@ -8,3 +8,15 @@ variable "tellerstech_email" {
   type        = string
   default     = ""
 }
+
+variable "ses_identity" {
+  description = "SES sending identity (domain) that bounce/complaint feedback is configured for"
+  type        = string
+  default     = "tellerstech.com"
+}
+
+variable "ses_feedback_endpoint" {
+  description = "HTTPS webhook that receives SES bounce/complaint SNS notifications. Suppression is applied globally by email, so one endpoint covers all lists (OCB + SIW)."
+  type        = string
+  default     = "https://www.tellerstech.com/wp-json/tellerstech/v1/ocb-ses-notification"
+}


### PR DESCRIPTION
## Summary

Configures the SES bounce/complaint feedback loop for the `tellerstech.com` sending identity so undeliverable/complained addresses are automatically suppressed and surfaced in the OCB/SIW admin dashboards.

**Why:** SES currently has only *email feedback forwarding* enabled (no `ComplaintTopic` / `BounceTopic`). As a result, complaint/bounce events never reach the site webhook — the dashboards show `0 Complained` / `0 Bounced` even after a confirmed test send to `complaint@simulator.amazonses.com`. The server's IAM role also lacks `SNS:*` write permissions, so this must be managed here in Terraform.

## What this adds (`aws/global/ses/feedback-notifications.tf`)

- `aws_sns_topic.ses_feedback` — `tellerstech-ses-notifications`
- `aws_sns_topic_policy.ses_feedback` — allows `ses.amazonaws.com` to publish, scoped to this account
- `aws_sns_topic_subscription.ses_feedback_webhook` — HTTPS subscription to the WP webhook
- `aws_ses_identity_notification_topic` for **Complaint** and **Bounce** (with original headers)
- New vars `ses_identity` (default `tellerstech.com`) and `ses_feedback_endpoint` (default the OCB webhook), plus topic ARN/name outputs

## Flow

```
SES (Bounce|Complaint) -> SNS topic -> HTTPS subscription -> WP webhook (tt_sub_handle_sns)
```

The webhook verifies the SNS signature, **auto-confirms** the subscription handshake (so the subscription becomes `Confirmed` with no manual step), and suppresses **globally by email** — so a single subscription covers both OCB and SIW lists.

## Notes

- The SES domain identity is provisioned outside this repo, so it's referenced by name via `var.ses_identity` rather than as a managed resource.
- Reuses the existing `data.aws_caller_identity.current` from `email-forwarding.tf`.
- Email feedback forwarding is intentionally left untouched (not disabled) to avoid changing current inbox behavior.

## Test plan

- [ ] `terraform plan` shows only the 5 new SES/SNS resources (no unexpected changes)
- [ ] After apply: SNS console shows the HTTPS subscription as `Confirmed`
- [ ] `aws ses get-identity-notification-attributes --identities tellerstech.com` shows `ComplaintTopic` + `BounceTopic` set
- [ ] Send to `complaint@simulator.amazonses.com` → subscriber flips to `complained` and dashboard count increments

Made with [Cursor](https://cursor.com)