### PR TITLE
feat(iam): grant WBAT_Main_Server read-only SNS diagnostics

### DIFF
--- a/aws/global/iam/role-WBAT_Main_Server.tf
+++ b/aws/global/iam/role-WBAT_Main_Server.tf
@@ -81,6 +81,41 @@ resource "aws_iam_role_policy" "WBAT_Main_Server-BriefsBackup" {
   })
 }
 
+# Read-only SNS diagnostics: lets the server inspect the SES bounce/complaint
+# feedback topic + its subscriptions from the box (e.g. confirm the HTTPS
+# subscription is Confirmed). No publish/subscribe/modify — describe only.
+resource "aws_iam_role_policy" "WBAT_Main_Server-SNSReadOnly" {
+  name = "SNSReadOnly"
+  role = aws_iam_role.WBAT_Main_Server.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "SNSDescribeTopics"
+        Effect = "Allow"
+        Action = [
+          "sns:GetTopicAttributes",
+          "sns:ListSubscriptionsByTopic",
+          "sns:GetSubscriptionAttributes"
+        ]
+        # Topic + subscription ARNs in this account/region (provider is us-east-1).
+        Resource = "arn:aws:sns:us-east-1:${data.aws_caller_identity.current.account_id}:*"
+      },
+      {
+        # Account-level list APIs don't support resource-level scoping.
+        Sid    = "SNSListAll"
+        Effect = "Allow"
+        Action = [
+          "sns:ListTopics",
+          "sns:ListSubscriptions"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
 resource "aws_iam_instance_profile" "WBAT_Main_Server" {
   name = "WBAT_Main_Server"
   role = aws_iam_role.WBAT_Main_Server.name


### PR DESCRIPTION
## Summary

Grants the `WBAT_Main_Server` instance role **read-only** SNS describe permissions so we can inspect the SES bounce/complaint feedback topic + its subscriptions directly from the server.

Today the server hits `AuthorizationError` on `sns:ListSubscriptionsByTopic` (and similar), so there's no way to confirm the HTTPS subscription is `Confirmed` from the box during diagnostics.

## What it adds

New inline policy `SNSReadOnly` on the role (matches the existing inline-policy pattern, e.g. `CloudFrontInvalidation`):

- **Topic/subscription-scoped** (`arn:aws:sns:us-east-1:<account>:*`): `sns:GetTopicAttributes`, `sns:ListSubscriptionsByTopic`, `sns:GetSubscriptionAttributes`
- **Account-level** (`*`, since these APIs can't be resource-scoped): `sns:ListTopics`, `sns:ListSubscriptions`

No publish / subscribe / modify — describe only. Provider is single-region `us-east-1`, matching the SES/SNS topic.

## Test plan
- [x] `terraform fmt` + `terraform validate` clean
- [ ] `terraform plan` shows only the new `aws_iam_role_policy.WBAT_Main_Server-SNSReadOnly`
- [ ] After apply, from the server: `aws sns list-subscriptions-by-topic --topic-arn arn:aws:sns:us-east-1:708113892725:tellerstech-ses-notifications --region us-east-1` succeeds and shows the webhook subscription as `Confirmed`

Made with [Cursor](https://cursor.com)