### PR TITLE
feat(cloudfront): cap Ship It Weekly podcast pages at 12h TTL

### DIFF
--- a/aws/global/cloudfront/tellerstech-website.tf
+++ b/aws/global/cloudfront/tellerstech-website.tf
@@ -34,6 +34,40 @@ resource "aws_cloudfront_cache_policy" "wordpress" {
   }
 }
 
+# Cache policy for the Ship It Weekly podcast pages - same as WordPress policy
+# but capped at 12 hours so these pages refresh at least twice a day.
+resource "aws_cloudfront_cache_policy" "podcast" {
+  name        = "Podcast-CachePolicy"
+  comment     = "Cache policy for Ship It Weekly podcast pages - 12 hour max TTL"
+  min_ttl     = 0
+  default_ttl = 7200  # 2 hours
+  max_ttl     = 43200 # 12 hours
+
+  parameters_in_cache_key_and_forwarded_to_origin {
+    enable_accept_encoding_gzip   = true
+    enable_accept_encoding_brotli = true
+
+    cookies_config {
+      cookie_behavior = "whitelist"
+      cookies {
+        items = [
+          "wordpress_*",
+          "wp-*",
+          "comment_*",
+        ]
+      }
+    }
+
+    headers_config {
+      header_behavior = "none"
+    }
+
+    query_strings_config {
+      query_string_behavior = "all"
+    }
+  }
+}
+
 # Cache policy for static assets - no cookies, long TTL
 resource "aws_cloudfront_cache_policy" "static_assets" {
   name        = "StaticAssets-CachePolicy"
@@ -161,6 +195,20 @@ resource "aws_cloudfront_distribution" "tellerstech_website" {
     viewer_protocol_policy   = "redirect-to-https"
     compress                 = true
     cache_policy_id          = aws_cloudfront_cache_policy.wordpress.id
+    origin_request_policy_id = aws_cloudfront_origin_request_policy.wordpress.id
+  }
+
+  # Ship It Weekly podcast pages - capped at 12 hours (Podcast-CachePolicy).
+  # The "/*" pattern also matches the bare "/ship-it-weekly-podcast/" path since
+  # CloudFront wildcards match zero or more characters.
+  ordered_cache_behavior {
+    path_pattern             = "/ship-it-weekly-podcast/*"
+    allowed_methods          = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods           = ["GET", "HEAD"]
+    target_origin_id         = "wordpress-origin"
+    viewer_protocol_policy   = "redirect-to-https"
+    compress                 = true
+    cache_policy_id          = aws_cloudfront_cache_policy.podcast.id
     origin_request_policy_id = aws_cloudfront_origin_request_policy.wordpress.id
   }
 

--- a/aws/global/cloudfront/tellerstech-website.tf
+++ b/aws/global/cloudfront/tellerstech-website.tf
@@ -34,11 +34,13 @@ resource "aws_cloudfront_cache_policy" "wordpress" {
   }
 }
 
-# Cache policy for the Ship It Weekly podcast pages - same as WordPress policy
-# but capped at 12 hours so these pages refresh at least twice a day.
+# Cache policy for the high-traffic Ship It Weekly landing pages (hub, host,
+# media kit) - same as WordPress policy but capped at 12 hours so these pages
+# refresh at least twice a day. Individual episodes are NOT included here and
+# keep the default 1 day ceiling.
 resource "aws_cloudfront_cache_policy" "podcast" {
   name        = "Podcast-CachePolicy"
-  comment     = "Cache policy for Ship It Weekly podcast pages - 12 hour max TTL"
+  comment     = "Cache policy for key Ship It Weekly landing pages - 12 hour max TTL"
   min_ttl     = 0
   default_ttl = 7200  # 2 hours
   max_ttl     = 43200 # 12 hours
@@ -198,11 +200,37 @@ resource "aws_cloudfront_distribution" "tellerstech_website" {
     origin_request_policy_id = aws_cloudfront_origin_request_policy.wordpress.id
   }
 
-  # Ship It Weekly podcast pages - capped at 12 hours (Podcast-CachePolicy).
-  # The "/*" pattern also matches the bare "/ship-it-weekly-podcast/" path since
-  # CloudFront wildcards match zero or more characters.
+  # Ship It Weekly hub page - capped at 12 hours (Podcast-CachePolicy) so the
+  # latest-episodes list does not go stale. EXACT match: the pattern has no "*",
+  # so it matches only "/ship-it-weekly-podcast/" and NOT the episode pages
+  # underneath it (e.g. /ship-it-weekly-podcast/<slug>/), which keep the default
+  # 1 day ceiling.
   ordered_cache_behavior {
-    path_pattern             = "/ship-it-weekly-podcast/*"
+    path_pattern             = "/ship-it-weekly-podcast/"
+    allowed_methods          = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods           = ["GET", "HEAD"]
+    target_origin_id         = "wordpress-origin"
+    viewer_protocol_policy   = "redirect-to-https"
+    compress                 = true
+    cache_policy_id          = aws_cloudfront_cache_policy.podcast.id
+    origin_request_policy_id = aws_cloudfront_origin_request_policy.wordpress.id
+  }
+
+  # Ship It Weekly host page - capped at 12 hours (exact match).
+  ordered_cache_behavior {
+    path_pattern             = "/ship-it-weekly-podcast/host/"
+    allowed_methods          = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods           = ["GET", "HEAD"]
+    target_origin_id         = "wordpress-origin"
+    viewer_protocol_policy   = "redirect-to-https"
+    compress                 = true
+    cache_policy_id          = aws_cloudfront_cache_policy.podcast.id
+    origin_request_policy_id = aws_cloudfront_origin_request_policy.wordpress.id
+  }
+
+  # Ship It Weekly media kit - capped at 12 hours (exact match).
+  ordered_cache_behavior {
+    path_pattern             = "/ship-it-weekly-podcast/media-kit/"
     allowed_methods          = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
     cached_methods           = ["GET", "HEAD"]
     target_origin_id         = "wordpress-origin"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Two related CloudFront changes for `www.tellerstech.com`:

1. **Cap TTL on key Ship It Weekly landing pages** so they don't go stale, while leaving episodes/other pages on the default 1-day ceiling.
2. **Forward CloudFront's viewer geolocation headers** to the origin so OCB newsletter analytics can geolocate subscribers (including IPv6 signups) reliably.

## 1. Ship It Weekly landing-page TTL

Pages capped at **12h** (`Podcast-CachePolicy`, exact-match behaviors):
- `/ship-it-weekly-podcast/` — hub page (lists latest episodes)
- `/ship-it-weekly-podcast/host/`
- `/ship-it-weekly-podcast/media-kit/`

Everything else — including episodes at `/ship-it-weekly-podcast/<slug>/` — falls through to the default behavior (2h default TTL, 1 day max). Exact-match (no `*`) is used because episodes share the path prefix; a wildcard would have wrongly capped every episode.

URL verification (live): hub / host / media-kit all `200`; media-kit no-slash `301`s to slash; episodes `200` and left at default.

## 2. Viewer geolocation headers for OCB analytics

Background: OCB signups were logging IPv6 addresses (the distribution has `is_ipv6_enabled = true`, and the origin reads the real client IP from `CloudFront-Viewer-Address`). A viewer that connects over IPv6 has no derivable IPv4, and a MaxMind lookup can silently fail on IPv6 if the address/port isn't parsed correctly.

Fix: add CloudFront's edge-generated geolocation headers to the `WordPress-OriginRequestPolicy` whitelist. CloudFront populates these for **both IPv4 and IPv6** viewers, so OCB analytics can read geo directly without depending on a MaxMind IPv6 lookup:

- `CloudFront-Viewer-Country`
- `CloudFront-Viewer-Country-Name`
- `CloudFront-Viewer-Country-Region`
- `CloudFront-Viewer-Country-Region-Name`
- `CloudFront-Viewer-City`
- `CloudFront-Viewer-Postal-Code`
- `CloudFront-Viewer-Latitude`
- `CloudFront-Viewer-Longitude`
- `CloudFront-Viewer-Time-Zone`

Forwarded via the **origin request policy only** (not the cache policy), so they don't become part of the cache key or fragment the page cache.

Follow-up (WordPress app, not this repo): the OCB analytics code needs to actually read these headers. IPv6 remains enabled.

## Validation

- `terraform fmt` clean.
- `terraform validate` passes.
- TFC will apply on merge.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-18f66bde-35d1-482f-a2a6-eb1df126a167"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-18f66bde-35d1-482f-a2a6-eb1df126a167"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

