### PR TITLE
feat(ec2): primary EBS shrink — 200GB cutover, EIP imports, migration scripts

### DIFF
--- a/aws/imports.tf
+++ b/aws/imports.tf
@@ -12,7 +12,27 @@
 # EC2 Instances - importing existing "pet" servers into Terraform management
 import {
   to = module.us-east-1.module.ec2.aws_instance.primary
-  id = "i-0572702f0a58f6dcd"
+  id = "i-0118b8ede80b52ef7"
+}
+
+import {
+  to = module.us-east-1.module.ec2.aws_eip.primary
+  id = "eipalloc-0e4834de5c1e13061"
+}
+
+import {
+  to = module.us-east-1.module.ec2.aws_eip_association.primary
+  id = "eipassoc-007018a225625abbb"
+}
+
+import {
+  to = module.us-east-1.module.ec2.aws_eip.secondary
+  id = "eipalloc-08734964d45fd5694"
+}
+
+import {
+  to = module.us-east-1.module.ec2.aws_eip_association.secondary
+  id = "eipassoc-0830bef1c1753210c"
 }
 
 import {

--- a/aws/us-east-1/ec2/data_sources.tf
+++ b/aws/us-east-1/ec2/data_sources.tf
@@ -8,7 +8,7 @@ data "aws_ebs_snapshot" "primary" {
 
   filter {
     name   = "volume-size"
-    values = ["300"]
+    values = ["600"]
   }
 
   filter {

--- a/aws/us-east-1/ec2/data_sources.tf
+++ b/aws/us-east-1/ec2/data_sources.tf
@@ -8,7 +8,7 @@ data "aws_ebs_snapshot" "primary" {
 
   filter {
     name   = "volume-size"
-    values = ["600"]
+    values = ["300"]
   }
 
   filter {

--- a/aws/us-east-1/ec2/eip.tf
+++ b/aws/us-east-1/ec2/eip.tf
@@ -1,0 +1,34 @@
+# Elastic IPs for primary and secondary servers (pre-existing, imported)
+resource "aws_eip" "primary" {
+  domain = "vpc"
+
+  tags = merge(
+    var.core_tags,
+    {
+      Name       = "WBAT Primary Server"
+      "scm:file" = "aws/us-east-1/ec2/eip.tf",
+    },
+  )
+}
+
+resource "aws_eip_association" "primary" {
+  allocation_id = aws_eip.primary.id
+  instance_id   = aws_instance.primary.id
+}
+
+resource "aws_eip" "secondary" {
+  domain = "vpc"
+
+  tags = merge(
+    var.core_tags,
+    {
+      Name       = "WBAT Secondary Server"
+      "scm:file" = "aws/us-east-1/ec2/eip.tf",
+    },
+  )
+}
+
+resource "aws_eip_association" "secondary" {
+  allocation_id = aws_eip.secondary.id
+  instance_id   = aws_instance.secondary.id
+}

--- a/aws/us-east-1/ec2/primary-instance.tf
+++ b/aws/us-east-1/ec2/primary-instance.tf
@@ -5,7 +5,9 @@ resource "aws_instance" "primary" {
   instance_type        = var.primary_instance_type
   key_name             = aws_key_pair.wbat.key_name
   iam_instance_profile = var.instance_profile_name-WBAT_Main_Server
-  ebs_optimized        = true
+  # Cutover instance i-0118b8ede80b52ef7 launched with EbsOptimized=false;
+  # changing to true forces instance replacement.
+  ebs_optimized        = false
   monitoring           = false
 
   subnet_id                   = data.aws_subnet.selected.id

--- a/aws/us-east-1/ec2/primary-instance.tf
+++ b/aws/us-east-1/ec2/primary-instance.tf
@@ -7,8 +7,8 @@ resource "aws_instance" "primary" {
   iam_instance_profile = var.instance_profile_name-WBAT_Main_Server
   # Cutover instance i-0118b8ede80b52ef7 launched with EbsOptimized=false;
   # changing to true forces instance replacement.
-  ebs_optimized        = false
-  monitoring           = false
+  ebs_optimized = false
+  monitoring    = false
 
   subnet_id                   = data.aws_subnet.selected.id
   vpc_security_group_ids      = [data.aws_security_group.default.id]

--- a/aws/us-east-1/ec2/primary-instance.tf
+++ b/aws/us-east-1/ec2/primary-instance.tf
@@ -20,7 +20,7 @@ resource "aws_instance" "primary" {
 
   root_block_device {
     volume_type           = "gp3"
-    volume_size           = 600
+    volume_size           = 200
     iops                  = 3000
     throughput            = 125
     encrypted             = true

--- a/aws/us-east-1/ec2/primary-instance.tf
+++ b/aws/us-east-1/ec2/primary-instance.tf
@@ -20,6 +20,7 @@ resource "aws_instance" "primary" {
 
   root_block_device {
     volume_type           = "gp3"
+    volume_size           = 800
     iops                  = 3000
     throughput            = 125
     encrypted             = true

--- a/aws/us-east-1/ec2/primary-instance.tf
+++ b/aws/us-east-1/ec2/primary-instance.tf
@@ -20,7 +20,7 @@ resource "aws_instance" "primary" {
 
   root_block_device {
     volume_type           = "gp3"
-    volume_size           = 800
+    volume_size           = 600
     iops                  = 3000
     throughput            = 125
     encrypted             = true

--- a/aws/us-east-1/ec2/secondary-instance.tf
+++ b/aws/us-east-1/ec2/secondary-instance.tf
@@ -18,6 +18,7 @@ resource "aws_instance" "secondary" {
 
   root_block_device {
     volume_type           = "gp3"
+    volume_size           = 200
     iops                  = 3000
     throughput            = 125
     encrypted             = true

--- a/scripts/shrink-cleanup-old.sh
+++ b/scripts/shrink-cleanup-old.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Terminate retired primary instance and 600 GB root volume after bake period.
+# Usage: shrink-cleanup-old.sh [--yes] [--dry-run]
+set -euo pipefail
+
+AWS_PROFILE="${AWS_PROFILE:-wbat}"
+OLD_INSTANCE_ID="${OLD_INSTANCE_ID:-i-0572702f0a58f6dcd}"
+OLD_VOLUME_ID="${OLD_VOLUME_ID:-vol-0d5064ffa1256b9fa}"
+CUTOVER_DATE="${CUTOVER_DATE:-2026-06-30}"
+BAKE_DAYS="${BAKE_DAYS:-7}"
+DRY_RUN=false
+YES=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    --yes) YES=true ;;
+    -h|--help)
+      echo "Usage: $0 [--dry-run] [--yes]"
+      echo "  Retires OLD primary after ${BAKE_DAYS}-day bake from CUTOVER_DATE=${CUTOVER_DATE}"
+      exit 0
+      ;;
+  esac
+done
+
+aws_cmd() {
+  aws --profile "$AWS_PROFILE" "$@"
+}
+
+cutover_epoch=$(date -j -f "%Y-%m-%d" "$CUTOVER_DATE" "+%s" 2>/dev/null || date -d "$CUTOVER_DATE" "+%s")
+now_epoch=$(date "+%s")
+bake_seconds=$((BAKE_DAYS * 86400))
+elapsed=$((now_epoch - cutover_epoch))
+
+if [[ "$elapsed" -lt "$bake_seconds" ]]; then
+  remaining=$(( (bake_seconds - elapsed) / 86400 + 1 ))
+  echo "ERROR: Bake period not complete. ~${remaining} day(s) remaining (cutover ${CUTOVER_DATE}, bake ${BAKE_DAYS}d)."
+  echo "Override only if you accept rollback risk: CUTOVER_DATE=... BAKE_DAYS=0 $0 --yes"
+  exit 1
+fi
+
+echo "=== OLD instance state ==="
+aws_cmd ec2 describe-instances --instance-ids "$OLD_INSTANCE_ID" \
+  --query 'Reservations[0].Instances[0].{State:State.Name,Name:Tags[?Key==`Name`].Value|[0]}' --output table
+
+echo "=== OLD root volume ==="
+aws_cmd ec2 describe-volumes --volume-ids "$OLD_VOLUME_ID" \
+  --query 'Volumes[0].{State:State,Size:Size,Attachments:Attachments}' --output json
+
+if [[ "$DRY_RUN" == true ]]; then
+  echo "DRY RUN: would snapshot ${OLD_VOLUME_ID}, terminate ${OLD_INSTANCE_ID}, delete volume after snap"
+  exit 0
+fi
+
+if [[ "$YES" != true ]]; then
+  read -r -p "Terminate ${OLD_INSTANCE_ID} and delete ${OLD_VOLUME_ID}? [y/N] " ans
+  [[ "$ans" =~ ^[yY] ]] || { echo "Aborted."; exit 1; }
+fi
+
+SNAP_NAME="primary-old-retired-${CUTOVER_DATE}"
+echo "Creating final snapshot of ${OLD_VOLUME_ID}..."
+SNAP_ID=$(aws_cmd ec2 create-snapshot \
+  --volume-id "$OLD_VOLUME_ID" \
+  --description "OLD primary retired after shrink cutover ${CUTOVER_DATE}" \
+  --tag-specifications "ResourceType=snapshot,Tags=[{Key=Name,Value=${SNAP_NAME}}]" \
+  --query SnapshotId --output text)
+echo "Snapshot: ${SNAP_ID} (waiting...)"
+aws_cmd ec2 wait snapshot-completed --snapshot-ids "$SNAP_ID"
+
+STATE=$(aws_cmd ec2 describe-instances --instance-ids "$OLD_INSTANCE_ID" --query 'Reservations[0].Instances[0].State.Name' --output text)
+if [[ "$STATE" != "terminated" ]]; then
+  echo "Disabling API termination on ${OLD_INSTANCE_ID} if set..."
+  aws_cmd ec2 modify-instance-attribute --instance-id "$OLD_INSTANCE_ID" --no-disable-api-termination 2>/dev/null || true
+  echo "Terminating ${OLD_INSTANCE_ID}..."
+  aws_cmd ec2 terminate-instances --instance-ids "$OLD_INSTANCE_ID"
+  aws_cmd ec2 wait instance-terminated --instance-ids "$OLD_INSTANCE_ID"
+fi
+
+VOL_STATE=$(aws_cmd ec2 describe-volumes --volume-ids "$OLD_VOLUME_ID" --query 'Volumes[0].State' --output text 2>/dev/null || echo "deleted")
+if [[ "$VOL_STATE" == "available" ]]; then
+  echo "Deleting detached volume ${OLD_VOLUME_ID}..."
+  aws_cmd ec2 delete-volume --volume-id "$OLD_VOLUME_ID"
+elif [[ "$VOL_STATE" == "in-use" ]]; then
+  echo "Waiting for volume detach after terminate..."
+  sleep 30
+  aws_cmd ec2 delete-volume --volume-id "$OLD_VOLUME_ID" 2>/dev/null || echo "Delete volume manually if still attached"
+fi
+
+echo "Cleanup complete. Retained snapshot: ${SNAP_ID}"

--- a/scripts/shrink-migration-validate.sh
+++ b/scripts/shrink-migration-validate.sh
@@ -1,0 +1,390 @@
+#!/usr/bin/env bash
+# WBAT primary EBS shrink migration — validation helper
+# Install: /usr/local/sbin/shrink-migration-validate.sh on OLD and NEW
+# Usage: shrink-migration-validate.sh <mode> [args]
+set -euo pipefail
+
+MODE="${1:-help}"
+NEW_IP="${2:-}"
+OLD_IP="${OLD_IP:-172.30.0.87}"
+RSYNC_USER="${RSYNC_USER:-ec2-user}"
+RSYNC_SSH_OPTS="${RSYNC_SSH_OPTS:--o StrictHostKeyChecking=no -o ConnectTimeout=10}"
+RSYNC_PATH="${RSYNC_PATH:---rsync-path=sudo rsync}"
+EXPECTED_EIP="${EXPECTED_EIP:-44.214.133.234}"
+EXPECTED_HOSTNAME="${EXPECTED_HOSTNAME:-server.wbat.net}"
+RSYNC_EXCLUDES=(
+  --exclude=/proc/*
+  --exclude=/sys/*
+  --exclude=/dev/*
+  --exclude=/run/*
+  --exclude=/tmp/*
+  --exclude=/mnt/*
+  --exclude=/media/*
+  --exclude=/lost+found
+  --exclude=/swapfile
+  --exclude=/home/ec2-user/.ssh/authorized_keys
+)
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+pass() { echo -e "${GREEN}PASS${NC}: $*"; }
+fail() { echo -e "${RED}FAIL${NC}: $*"; ERRORS=$((ERRORS + 1)); }
+warn() { echo -e "${YELLOW}WARN${NC}: $*"; }
+info() { echo "INFO: $*"; }
+
+ERRORS=0
+SERVICES=(directadmin httpd nginx mysqld mariadb exim dovecot named)
+
+service_unit() {
+  local s="$1"
+  if systemctl list-unit-files "${s}.service" &>/dev/null; then
+    echo "${s}.service"
+  elif systemctl list-unit-files "mariadb.service" &>/dev/null && [[ "$s" == "mysqld" ]]; then
+    echo "mariadb.service"
+  else
+    echo "${s}.service"
+  fi
+}
+
+is_active() {
+  local unit
+  unit="$(service_unit "$1")"
+  systemctl is-active --quiet "$unit" 2>/dev/null
+}
+
+is_inactive() {
+  local unit
+  unit="$(service_unit "$1")"
+  ! systemctl is-active --quiet "$unit" 2>/dev/null
+}
+
+stop_production_services() {
+  info "Stopping production services (OLD server cutover prep)..."
+  systemctl stop crond 2>/dev/null || true
+  for s in directadmin httpd nginx mysqld mariadb exim dovecot named; do
+    unit="$(service_unit "$s")"
+    if systemctl list-unit-files "$unit" &>/dev/null; then
+      systemctl stop "$unit" 2>/dev/null || true
+      info "stopped $unit"
+    fi
+  done
+  sync
+  sleep 2
+  pass "stop_production_services completed"
+}
+
+verify_services_stopped() {
+  info "Verifying production services are stopped..."
+  local ok=1
+  for s in "${SERVICES[@]}"; do
+    unit="$(service_unit "$s")"
+    if systemctl list-unit-files "$unit" &>/dev/null; then
+      if is_active "$s"; then
+        fail "Service still active: $unit"
+        ok=0
+      else
+        pass "inactive: $unit"
+      fi
+    fi
+  done
+  if systemctl is-active --quiet crond 2>/dev/null; then
+    warn "crond still active (optional to stop)"
+  else
+    pass "crond inactive"
+  fi
+  [[ "$ok" -eq 1 ]] || return 1
+}
+
+verify_rsync_diff() {
+  local target_ip="${1:-$NEW_IP}"
+  [[ -n "$target_ip" ]] || { fail "verify_rsync_diff requires NEW_IP"; return 1; }
+  info "Dry-run rsync diff OLD -> ${target_ip} (must be empty)..."
+  local diff
+  diff="$(rsync -ani --delete "${RSYNC_EXCLUDES[@]}" $RSYNC_PATH -e "ssh $RSYNC_SSH_OPTS" \
+    / "${RSYNC_USER}@${target_ip}:/" 2>/dev/null | grep -E '^[<>ch.*]' || true)"
+  if [[ -z "$diff" ]]; then
+    pass "rsync dry-run: zero file differences"
+  else
+    fail "rsync dry-run shows differences:"
+    echo "$diff" | head -50
+    local count
+    count="$(echo "$diff" | wc -l)"
+    [[ "$count" -gt 50 ]] && info "... and $((count - 50)) more lines"
+    return 1
+  fi
+}
+
+compare_dir_counts() {
+  local target_ip="${1:-$NEW_IP}"
+  [[ -n "$target_ip" ]] || { fail "compare_dir_counts requires NEW_IP"; return 1; }
+  local dirs=(/home /usr/local/directadmin /var/lib/mysql /etc/httpd /etc/exim /root/.config/rclone)
+  info "Comparing file counts on key directories..."
+  for d in "${dirs[@]}"; do
+    [[ -d "$d" ]] || continue
+    local local_count remote_count remote_err
+    local_count="$(find "$d" -xdev -type f 2>/dev/null | wc -l)"
+    remote_err="$(ssh ${RSYNC_SSH_OPTS} "${RSYNC_USER}@${target_ip}" \
+      "sudo /usr/bin/find '$d' -xdev -type f 2>/dev/null | wc -l" 2>&1 >/dev/null || true)"
+    remote_count="$(ssh ${RSYNC_SSH_OPTS} "${RSYNC_USER}@${target_ip}" \
+      "sudo /usr/bin/find '$d' -xdev -type f 2>/dev/null | wc -l" 2>/dev/null || echo "ERR")"
+    if [[ "$remote_count" == "ERR" ]] || ! [[ "$remote_count" =~ ^[0-9]+$ ]]; then
+      fail "cannot read remote $d (${remote_err:-ssh/sudo failed})"
+    elif [[ "$local_count" == "$remote_count" ]]; then
+      pass "$d file count: $local_count"
+    else
+      fail "$d file count mismatch local=$local_count remote=$remote_count"
+    fi
+  done
+}
+
+sample_xattrs() {
+  local target_ip="${1:-}"
+  local samples=(/home /usr/local/directadmin/conf)
+  info "Sampling extended attributes (xattr) on critical paths..."
+  for base in "${samples[@]}"; do
+    [[ -d "$base" ]] || continue
+    local f
+    f="$(find "$base" -xdev -type f 2>/dev/null | head -1)"
+    [[ -n "$f" ]] || continue
+    if getfattr -d "$f" &>/dev/null; then
+      pass "local xattr readable: $f"
+    else
+      warn "no xattrs or getfattr unavailable on $f"
+    fi
+    if [[ -n "$target_ip" ]]; then
+      local remote_ok
+      remote_ok="$(ssh $RSYNC_SSH_OPTS "${RSYNC_USER}@${target_ip}" \
+        "sudo getfattr -d '$f' &>/dev/null && echo yes || echo no" 2>/dev/null || echo no)"
+      if [[ "$remote_ok" == "yes" ]]; then
+        pass "remote xattr readable: $f"
+      else
+        warn "remote xattr check failed for $f (path may differ pre-final-rsync)"
+      fi
+    fi
+  done
+}
+
+verify_fstab() {
+  info "Verifying /etc/fstab UUIDs exist on this system..."
+  local uuid line dev
+  while IFS= read -r line; do
+    [[ "$line" =~ ^# ]] && continue
+    [[ -z "${line// }" ]] && continue
+    if [[ "$line" =~ UUID=([0-9a-fA-F-]+) ]]; then
+      uuid="${BASH_REMATCH[1]}"
+      if blkid | grep -q "$uuid"; then
+        pass "fstab UUID present: $uuid"
+      else
+        fail "fstab UUID NOT found on disk: $uuid — line: $line"
+      fi
+    fi
+  done < /etc/fstab
+  if grep -q 'uquota,gquota' /etc/fstab; then
+    pass "fstab has xfs quota options"
+  else
+    warn "fstab missing uquota,gquota (check if quotas expected)"
+  fi
+}
+
+verify_boot_stack() {
+  info "Boot stack checks..."
+  if [[ -d /boot/efi ]]; then
+    pass "/boot/efi exists"
+  else
+    warn "/boot/efi missing"
+  fi
+  if [[ -f /boot/grub2/grub.cfg ]] || [[ -f /boot/grub/grub.cfg ]]; then
+    pass "grub.cfg present"
+  else
+    fail "grub.cfg not found"
+  fi
+  if ls /boot/initramfs-*.img &>/dev/null; then
+    pass "initramfs images present"
+  else
+    fail "no initramfs images in /boot"
+  fi
+}
+
+verify_disk_size() {
+  local min_avail_gb="${1:-50}"
+  info "Disk usage check..."
+  df -h /
+  local used_pct avail_kb
+  used_pct="$(df / | tail -1 | awk '{print $5}' | tr -d '%')"
+  avail_kb="$(df / | tail -1 | awk '{print $4}')"
+  local avail_gb=$((avail_kb / 1024 / 1024))
+  if [[ "$used_pct" -lt 85 ]]; then
+    pass "root filesystem ${used_pct}% used"
+  else
+    fail "root filesystem ${used_pct}% used (>85%)"
+  fi
+  if [[ "$avail_gb" -ge "$min_avail_gb" ]]; then
+    pass "available space ${avail_gb}GB (>= ${min_avail_gb}GB)"
+  else
+    fail "only ${avail_gb}GB free (need >= ${min_avail_gb}GB)"
+  fi
+}
+
+verify_config_paths() {
+  info "Critical config path checks..."
+  local paths=(
+    /usr/local/directadmin/directadmin
+    /usr/local/directadmin/scripts/custom/all_backups_post.sh
+    /root/.config/rclone/rclone.conf
+    /usr/local/sbin/verify-backups-s3.sh
+    /etc/named.conf
+  )
+  for p in "${paths[@]}"; do
+    if [[ -e "$p" ]]; then
+      pass "exists: $p"
+    else
+      fail "missing: $p"
+    fi
+  done
+}
+
+verify_da_license() {
+  info "DirectAdmin license check..."
+  if /usr/local/directadmin/directadmin license 2>/dev/null | grep -qiE 'valid|licensed|expires'; then
+    pass "DirectAdmin license command OK"
+  else
+    warn "DirectAdmin license output unclear — verify manually after EIP attach"
+  fi
+}
+
+verify_public_ip() {
+  info "Public IP check (post-cutover)..."
+  local ip
+  ip="$(curl -sf --max-time 5 ifconfig.me 2>/dev/null || curl -sf --max-time 5 icanhazip.com 2>/dev/null || true)"
+  if [[ "$ip" == "$EXPECTED_EIP" ]]; then
+    pass "public IP is $EXPECTED_EIP"
+  else
+    fail "public IP is '${ip:-unknown}' expected $EXPECTED_EIP"
+  fi
+}
+
+verify_hostname() {
+  local hn
+  hn="$(hostname -f 2>/dev/null || hostname)"
+  if [[ "$hn" == "$EXPECTED_HOSTNAME" ]]; then
+    pass "hostname: $hn"
+  else
+    fail "hostname '$hn' expected '$EXPECTED_HOSTNAME'"
+  fi
+}
+
+verify_stack_configs() {
+  info "Syntax checks for web/mail/DNS..."
+  if command -v httpd &>/dev/null; then
+    httpd -t &>/dev/null && pass "httpd -t" || fail "httpd -t"
+  fi
+  if command -v nginx &>/dev/null; then
+    nginx -t &>/dev/null && pass "nginx -t" || fail "nginx -t"
+  fi
+  if command -v named-checkconf &>/dev/null && [[ -f /etc/named.conf ]]; then
+    named-checkconf &>/dev/null && pass "named-checkconf" || fail "named-checkconf"
+  fi
+  if command -v mysql &>/dev/null && is_inactive mysqld; then
+    info "mysql skipped (mysqld stopped)"
+  elif command -v mysql &>/dev/null; then
+    mysql -e "SELECT 1" &>/dev/null && pass "mysql SELECT 1" || fail "mysql SELECT 1"
+  fi
+}
+
+start_production_services() {
+  info "Starting production services (NEW server post-cutover)..."
+  systemctl start crond 2>/dev/null || true
+  for s in mysqld mariadb named exim dovecot httpd nginx directadmin; do
+    unit="$(service_unit "$s")"
+    if systemctl list-unit-files "$unit" &>/dev/null; then
+      systemctl start "$unit" 2>/dev/null || warn "could not start $unit"
+    fi
+  done
+  pass "start_production_services completed"
+}
+
+run_pre_cutover() {
+  [[ -n "$NEW_IP" ]] || { fail "usage: $0 pre-cutover <NEW_IP>"; exit 1; }
+  verify_services_stopped
+  verify_rsync_diff "$NEW_IP"
+  compare_dir_counts "$NEW_IP"
+  sample_xattrs "$NEW_IP"
+}
+
+run_post_rsync_new() {
+  info "=== POST-RSYNC validation (run on NEW instance) ==="
+  verify_hostname
+  verify_fstab
+  verify_boot_stack
+  verify_disk_size 50
+  verify_config_paths
+  sample_xattrs
+}
+
+run_post_cutover() {
+  info "=== POST-CUTOVER validation (run on NEW instance after EIP) ==="
+  verify_hostname
+  verify_public_ip
+  verify_disk_size 50
+  verify_config_paths
+  verify_da_license
+  verify_stack_configs
+  if [[ -x /usr/local/sbin/verify-backups-s3.sh ]]; then
+    /usr/local/sbin/verify-backups-s3.sh && pass "S3 backup verify script" || warn "S3 verify script reported issues"
+  fi
+  for s in directadmin httpd nginx mysqld exim dovecot named; do
+    unit="$(service_unit "$s")"
+    if systemctl list-unit-files "$unit" &>/dev/null; then
+      is_active "$s" && pass "active: $unit" || fail "not active: $unit"
+    fi
+  done
+}
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") <mode> [NEW_IP]
+
+Modes:
+  stop-services       Stop crond + DA/mail/web/mysql/DNS (OLD, before final rsync)
+  verify-stopped      Confirm production services are inactive (OLD)
+  rsync-diff <IP>     Dry-run rsync must show zero differences (OLD)
+  compare-counts <IP> Compare file counts on key dirs (OLD)
+  xattrs [IP]         Sample extended attributes local [and remote]
+  pre-cutover <IP>    stop check + rsync-diff + counts + xattrs (OLD)
+  post-rsync-new      fstab/boot/disk/config checks (NEW, before EIP)
+  post-cutover        Full validation after EIP + services started (NEW)
+  start-services      Start production stack (NEW)
+
+Environment: OLD_IP, EXPECTED_EIP, EXPECTED_HOSTNAME
+EOF
+}
+
+case "$MODE" in
+  stop-services)      stop_production_services ;;
+  verify-stopped)     verify_services_stopped ;;
+  rsync-diff)         verify_rsync_diff "${2:-$NEW_IP}" ;;
+  compare-counts)     compare_dir_counts "${2:-$NEW_IP}" ;;
+  xattrs)             sample_xattrs "${2:-}" ;;
+  pre-cutover)        run_pre_cutover ;;
+  post-rsync-new)     run_post_rsync_new ;;
+  post-cutover)       run_post_cutover ;;
+  start-services)     start_production_services ;;
+  help|-h|--help)     usage ;;
+  *)
+    fail "unknown mode: $MODE"
+    usage
+    exit 1
+    ;;
+esac
+
+echo ""
+if [[ "$ERRORS" -eq 0 ]]; then
+  echo -e "${GREEN}All checks passed.${NC}"
+  exit 0
+else
+  echo -e "${RED}${ERRORS} check(s) failed.${NC}"
+  exit 1
+fi

--- a/scripts/shrink-migration.config.yaml
+++ b/scripts/shrink-migration.config.yaml
@@ -1,0 +1,83 @@
+# WBAT primary EBS shrink migration — static config
+# Used by scripts/shrink_migration.py
+
+aws_profile: wbat
+aws_region: us-east-1
+
+old:
+  instance_id: i-0572702f0a58f6dcd
+  private_ip: 172.30.0.87
+  root_volume_id: vol-0d5064ffa1256b9fa
+  name_tag: WBAT Primary Server OLD-retired
+
+new:
+  instance_id: i-0118b8ede80b52ef7
+  private_ip: 172.30.0.71
+  root_volume_id: vol-0e779cc0687ffc92c
+  name_tag_temp: WBAT-Primary-200-temp
+  name_tag_final: WBAT Primary Server
+
+eip:
+  public_ip: 44.214.133.234
+  allocation_id: eipalloc-0e4834de5c1e13061
+  association_id: eipassoc-007018a225625abbb
+
+expected:
+  hostname: server.wbat.net
+  root_size_gb: 200
+
+ssh:
+  user: ec2-user
+  # Do NOT set identity_file — root default ed25519 works on OLD; explicit -i breaks SSH
+  options:
+    - StrictHostKeyChecking=no
+    - ConnectTimeout=30
+
+rsync:
+  flags:
+    - -aHAxx
+    - --numeric-ids
+    - --info=progress2
+    - --rsync-path=sudo rsync
+  excludes:
+    - /proc/*
+    - /sys/*
+    - /dev/*
+    - /run/*
+    - /tmp/*
+    - /mnt/*
+    - /media/*
+    - /lost+found
+    - /swapfile
+    - /home/ec2-user/.ssh/authorized_keys
+
+s3:
+  bucket: wbat-tellerstech-directadmin-backups-708113892725
+  prefix: migration
+
+paths:
+  validate_script: /usr/local/sbin/shrink-migration-validate.sh
+  rsync_log_live: /var/log/shrink-rsync-live.log
+  rsync_log_final: /var/log/shrink-rsync-final.log
+
+snapshots:
+  pre_cutover: snap-0c562aad0c3c6b51f
+
+migration_pubkey: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO0g4NOwDAjrE3mBerrcX2f9qUmaYxuXTRKLf4Ga49ku root@server.wbat.net
+
+services:
+  - directadmin
+  - httpd
+  - nginx
+  - mysqld
+  - mariadb
+  - exim
+  - dovecot
+  - named
+
+# Retired primary (post-cutover) — not managed by Terraform; cleanup via shrink-cleanup-old.sh
+retired:
+  instance_id: i-0572702f0a58f6dcd
+  root_volume_id: vol-0d5064ffa1256b9fa
+  cutover_date: "2026-06-30"
+  bake_days: 7

--- a/scripts/shrink-rsync-live.sh
+++ b/scripts/shrink-rsync-live.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Live/final rsync for primary shrink migration (OLD -> NEW)
+# Run on OLD server as root. Avoids -X (SELinux xattrs); run restorecon on NEW after cutover.
+set -euo pipefail
+
+NEW_IP="${NEW_IP:-172.30.0.71}"
+RSYNC_USER="${RSYNC_USER:-ec2-user}"
+RSYNC_SSH="${RSYNC_SSH:-ssh -o StrictHostKeyChecking=no -o ConnectTimeout=30}"
+LOG="${LOG:-/var/log/shrink-rsync-live.log}"
+
+RSYNC_EXCLUDES=(
+  --exclude=/proc/*
+  --exclude=/sys/*
+  --exclude=/dev/*
+  --exclude=/run/*
+  --exclude=/tmp/*
+  --exclude=/mnt/*
+  --exclude=/media/*
+  --exclude=/lost+found
+  --exclude=/swapfile
+  --exclude=/home/ec2-user/.ssh/authorized_keys
+)
+
+# -aHAxx (no capital -X): skips SELinux security.selinux xattrs that fail on NEW receiver.
+# After cutover on NEW: restorecon -Rv /home /var/www /usr/local/directadmin
+RSYNC_FLAGS=(-aHAxx --numeric-ids --info=progress2 --rsync-path="sudo rsync")
+
+echo "=== rsync start $(date -Is) -> ${RSYNC_USER}@${NEW_IP} ===" | tee -a "$LOG"
+rsync "${RSYNC_FLAGS[@]}" -e "$RSYNC_SSH" "${RSYNC_EXCLUDES[@]}" / "${RSYNC_USER}@${NEW_IP}:/" 2>&1 | tee -a "$LOG"
+rc=${PIPESTATUS[0]}
+echo "=== rsync end $(date -Is) exit=$rc ===" | tee -a "$LOG"
+# exit 23 = partial (often xattr noise with old runs); 0 = clean
+if [[ "$rc" -eq 0 || "$rc" -eq 23 ]]; then
+  echo "DONE $(date -Is) exit=$rc" >> "$LOG"
+fi
+exit "$rc"

--- a/scripts/shrink_migration.py
+++ b/scripts/shrink_migration.py
@@ -1,0 +1,525 @@
+#!/usr/bin/env python3
+"""
+WBAT primary EBS shrink migration orchestrator (600 GB -> 200 GB, Option 1).
+
+Run on OLD production server as root for rsync/SSH/validation steps.
+Run from laptop (with --profile) for AWS EIP/tag/SSM recovery steps.
+
+Examples:
+  python3 shrink_migration.py status
+  python3 shrink_migration.py validate rsync-diff
+  python3 shrink_migration.py rsync live
+  python3 shrink_migration.py cutover preflight
+  python3 shrink_migration.py cutover final --yes
+  python3 shrink_migration.py aws fix-new-ssh
+  python3 shrink_migration.py aws eip-flip --yes
+  python3 shrink_migration.py aws rollback --yes
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import subprocess
+import sys
+import textwrap
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+try:
+    import yaml
+except ImportError:
+    yaml = None  # type: ignore
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+DEFAULT_CONFIG = SCRIPT_DIR / "shrink-migration.config.yaml"
+
+
+class MigrationError(Exception):
+    pass
+
+
+@dataclass
+class Config:
+    aws_profile: str = "wbat"
+    aws_region: str = "us-east-1"
+    old_instance_id: str = ""
+    old_private_ip: str = ""
+    new_instance_id: str = ""
+    new_private_ip: str = ""
+    eip_allocation_id: str = ""
+    eip_association_id: str = ""
+    eip_public_ip: str = ""
+    ssh_user: str = "ec2-user"
+    ssh_options: list[str] = field(default_factory=list)
+    rsync_flags: list[str] = field(default_factory=list)
+    rsync_excludes: list[str] = field(default_factory=list)
+    validate_script: str = "/usr/local/sbin/shrink-migration-validate.sh"
+    rsync_log_live: str = "/var/log/shrink-rsync-live.log"
+    rsync_log_final: str = "/var/log/shrink-rsync-final.log"
+    migration_pubkey: str = ""
+    s3_bucket: str = ""
+    s3_prefix: str = "migration"
+    expected_hostname: str = "server.wbat.net"
+    old_name_tag: str = "WBAT Primary Server"
+    new_name_tag_temp: str = "WBAT-Primary-200-temp"
+    new_name_tag_final: str = "WBAT Primary Server"
+    old_name_retired: str = "WBAT Primary Server OLD-retired"
+
+    @classmethod
+    def load(cls, path: Path) -> Config:
+        if not path.exists():
+            raise MigrationError(f"Config not found: {path}")
+        raw = path.read_text()
+        if yaml is not None:
+            data = yaml.safe_load(raw)
+        else:
+            # Minimal fallback if PyYAML missing — expect JSON-compatible YAML subset
+            raise MigrationError("PyYAML required: dnf install python3-pyyaml")
+        return cls.from_dict(data)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Config:
+        ssh = data.get("ssh", {})
+        rsync = data.get("rsync", {})
+        paths = data.get("paths", {})
+        return cls(
+            aws_profile=data.get("aws_profile", "wbat"),
+            aws_region=data.get("aws_region", "us-east-1"),
+            old_instance_id=data["old"]["instance_id"],
+            old_private_ip=data["old"]["private_ip"],
+            new_instance_id=data["new"]["instance_id"],
+            new_private_ip=data["new"]["private_ip"],
+            eip_allocation_id=data["eip"]["allocation_id"],
+            eip_association_id=data["eip"]["association_id"],
+            eip_public_ip=data["eip"]["public_ip"],
+            ssh_user=ssh.get("user", "ec2-user"),
+            ssh_options=list(ssh.get("options", [])),
+            rsync_flags=list(rsync.get("flags", [])),
+            rsync_excludes=list(rsync.get("excludes", [])),
+            validate_script=paths.get("validate_script", "/usr/local/sbin/shrink-migration-validate.sh"),
+            rsync_log_live=paths.get("rsync_log_live", "/var/log/shrink-rsync-live.log"),
+            rsync_log_final=paths.get("rsync_log_final", "/var/log/shrink-rsync-final.log"),
+            migration_pubkey=data.get("migration_pubkey", ""),
+            s3_bucket=data.get("s3", {}).get("bucket", ""),
+            s3_prefix=data.get("s3", {}).get("prefix", "migration"),
+            expected_hostname=data.get("expected", {}).get("hostname", "server.wbat.net"),
+            old_name_tag=data["old"].get("name_tag", "WBAT Primary Server"),
+            new_name_tag_temp=data["new"].get("name_tag_temp", "WBAT-Primary-200-temp"),
+            new_name_tag_final=data["new"].get("name_tag_final", "WBAT Primary Server"),
+        )
+
+
+def log(msg: str) -> None:
+    print(msg, flush=True)
+
+
+def run(
+    cmd: Sequence[str],
+    *,
+    check: bool = True,
+    capture: bool = False,
+    input_text: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    display = " ".join(shlex.quote(c) for c in cmd)
+    log(f"$ {display}")
+    return subprocess.run(
+        list(cmd),
+        check=check,
+        text=True,
+        capture_output=capture,
+        input=input_text,
+    )
+
+
+def aws_base(cfg: Config) -> list[str]:
+    return ["aws", "--profile", cfg.aws_profile, "--region", cfg.aws_region]
+
+
+def ssh_target(cfg: Config, ip: str | None = None) -> str:
+    return f"{cfg.ssh_user}@{ip or cfg.new_private_ip}"
+
+
+def ssh_cmd(cfg: Config, remote_cmd: str, *, ip: str | None = None) -> list[str]:
+    opts = [f"-o {o}" for o in cfg.ssh_options]
+    return ["ssh", *opts, ssh_target(cfg, ip), remote_cmd]
+
+
+def rsync_cmd(cfg: Config, *, delete: bool = False, log_path: str | None = None) -> list[str]:
+    opts = [f"-o {o}" for o in cfg.ssh_options]
+    cmd = [
+        "rsync",
+        *cfg.rsync_flags,
+        *([] if not delete else ["--delete"]),
+        *sum([["--exclude", e] for e in cfg.rsync_excludes], []),
+        "-e",
+        " ".join(["ssh", *opts]),
+        "/",
+        f"{ssh_target(cfg)}:/",
+    ]
+    return cmd
+
+
+def require_root() -> None:
+    if os.geteuid() != 0:
+        raise MigrationError("This command must run as root on OLD server")
+
+
+def confirm(prompt: str, yes: bool) -> None:
+    if yes:
+        log(f"CONFIRMED: {prompt}")
+        return
+    try:
+        answer = input(f"{prompt} [y/N]: ").strip().lower()
+    except EOFError:
+        answer = "n"
+    if answer not in ("y", "yes"):
+        raise MigrationError("Aborted by user")
+
+
+def ssm_run(cfg: Config, instance_id: str, commands: list[str], timeout: int = 120) -> str:
+    params = json.dumps({"commands": commands})
+    out = run(
+        [
+            *aws_base(cfg),
+            "ssm",
+            "send-command",
+            "--instance-ids",
+            instance_id,
+            "--document-name",
+            "AWS-RunShellScript",
+            "--timeout-seconds",
+            str(timeout),
+            "--parameters",
+            params,
+            "--query",
+            "Command.CommandId",
+            "--output",
+            "text",
+        ],
+        capture=True,
+    )
+    cmd_id = out.stdout.strip()
+    log(f"SSM command id: {cmd_id}")
+    for _ in range(30):
+        time.sleep(2)
+        inv = run(
+            [
+                *aws_base(cfg),
+                "ssm",
+                "get-command-invocation",
+                "--command-id",
+                cmd_id,
+                "--instance-id",
+                instance_id,
+                "--output",
+                "json",
+            ],
+            capture=True,
+            check=False,
+        )
+        data = json.loads(inv.stdout or "{}")
+        status = data.get("Status", "")
+        if status in ("Success", "Failed", "Cancelled", "TimedOut"):
+            stdout = data.get("StandardOutputContent", "")
+            stderr = data.get("StandardErrorContent", "")
+            log(stdout)
+            if stderr:
+                log(stderr)
+            if status != "Success":
+                raise MigrationError(f"SSM command {status}")
+            return cmd_id
+    raise MigrationError("SSM command timed out waiting for completion")
+
+
+def cmd_status(cfg: Config) -> None:
+    log("=== OLD disk ===")
+    run(["df", "-h", "/"])
+    run(["du", "-xsh", "/home", "/usr/local/directadmin", "/var/lib/mysql"], check=False)
+
+    log("\n=== SSH to NEW ===")
+    try:
+        run(ssh_cmd(cfg, "echo SSH_OK && df -h / && test -x /usr/local/directadmin/directadmin && echo DA_OK"))
+    except subprocess.CalledProcessError as exc:
+        log(f"SSH FAILED (run: aws fix-new-ssh): exit {exc.returncode}")
+
+    log("\n=== rsync-diff gate ===")
+    run([cfg.validate_script, "rsync-diff", cfg.new_private_ip], check=False)
+
+
+def cmd_validate(cfg: Config, mode: str) -> None:
+    args = [cfg.validate_script, mode]
+    if mode in ("rsync-diff", "compare-counts", "pre-cutover", "xattrs"):
+        args.append(cfg.new_private_ip)
+    run(args)
+
+
+def cmd_rsync(cfg: Config, phase: str, yes: bool) -> None:
+    require_root()
+    delete = phase == "final"
+    log_path = cfg.rsync_log_final if delete else cfg.rsync_log_live
+    if delete:
+        confirm("Final rsync STOPS production on OLD first. Continue?", yes)
+        run([cfg.validate_script, "stop-services"])
+        run([cfg.validate_script, "verify-stopped"])
+
+    cmd = rsync_cmd(cfg, delete=delete)
+    log(f"=== rsync {phase} -> {log_path} ===")
+    with open(log_path, "a", encoding="utf-8") as fh:
+        fh.write(f"\n=== shrink_migration.py {phase} start ===\n")
+        fh.flush()
+        proc = subprocess.run(cmd, stdout=fh, stderr=subprocess.STDOUT)
+    if proc.returncode not in (0, 23):
+        raise MigrationError(f"rsync failed with exit {proc.returncode}")
+    log(f"rsync exit={proc.returncode}")
+
+    if delete:
+        run([cfg.validate_script, "pre-cutover", cfg.new_private_ip])
+
+
+def cmd_cutover_preflight(cfg: Config) -> None:
+    run([cfg.validate_script, "rsync-diff", cfg.new_private_ip])
+    run(ssh_cmd(cfg, "sudo du -xsh / /home /usr/local/directadmin /var/lib/mysql"), check=False)
+    log("Preflight OK — safe to run: cutover final")
+
+
+def cmd_cutover_boot_prep(cfg: Config) -> None:
+    run(ssh_cmd(cfg, f"sudo {cfg.validate_script} post-rsync-new"))
+    run(
+        ssh_cmd(
+            cfg,
+            "sudo grub2-install /dev/nvme0n1 && sudo dracut -f --regenerate-all && echo BOOT_PREP_OK",
+        )
+    )
+    log("Reboot NEW manually, verify SSH, then: aws eip-flip")
+
+
+def cmd_aws_fix_new_ssh(cfg: Config, yes: bool) -> None:
+    confirm(f"Reboot NEW {cfg.new_instance_id} and restore SSH keys via SSM?", yes)
+    run([*aws_base(cfg), "ec2", "reboot-instances", "--instance-ids", cfg.new_instance_id])
+    log("Waiting 90s for reboot...")
+    time.sleep(90)
+    pubkey = cfg.migration_pubkey
+    wbat_rsa = (
+        "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDAbfdIFRhw+NFOytsJgWNRuCwpDSIrYm1g0UOpMQ1N8/"
+        "yNiYKnREARbah2p8RMqnf0Hu054DEwfdtR836STs2txbFnZmfZgiVfAfjZQSqCuxMNmccJD3kQSOVHXU5L/"
+        "2t+XIw8IDDzB+4EuWoOuO1BlYTu+GdTPgVDcHyhlqE2BfD329DoJ2CTui1EE14OupmPDztW8Rl1Hwz7ud4TJ0"
+        "hhWZb07fFP35yvjDdKaknwcPzsa/IH2V4eZ7gDDQUl+TppTB9Ohx8tfMWwjFBNR86C2UqJxUCz3VAA/YRoPY7BCxsJ1"
+        "Iu+GhNmM9pPlmIkFXbI+DRS6sgrJ9W3ouRkTpzL WBAT"
+    )
+    commands = [
+        "setenforce 0 2>/dev/null || true",
+        "mkdir -p /home/ec2-user/.ssh && chmod 700 /home/ec2-user/.ssh",
+        f'printf "%s\\n%s\\n" "{wbat_rsa}" "{pubkey}" > /home/ec2-user/.ssh/authorized_keys',
+        "chmod 600 /home/ec2-user/.ssh/authorized_keys",
+        "chown -R ec2-user:ec2-user /home/ec2-user/.ssh",
+        'printf "ec2-user ALL=(ALL) NOPASSWD: /usr/bin/rsync\\nec2-user ALL=(ALL) NOPASSWD: /usr/bin/find\\nec2-user ALL=(ALL) NOPASSWD: /usr/bin/getfattr\\n" > /etc/sudoers.d/shrink-migrate',
+        "chmod 440 /etc/sudoers.d/shrink-migrate",
+        "visudo -cf /etc/sudoers.d/shrink-migrate",
+        "systemctl restart sshd",
+        "echo SSH_FIXED",
+    ]
+    ssm_run(cfg, cfg.new_instance_id, commands)
+    log("On OLD run: ssh-keygen -R {ip}; ssh-keyscan -H {ip} >> /root/.ssh/known_hosts".format(ip=cfg.new_private_ip))
+    log(f"Then test: ssh -o StrictHostKeyChecking=no {ssh_target(cfg)} 'echo OK'")
+
+
+def cmd_aws_eip_flip(cfg: Config, yes: bool) -> None:
+    confirm(
+        f"Disassociate EIP {cfg.eip_public_ip} from OLD and attach to NEW {cfg.new_instance_id}?",
+        yes,
+    )
+    run([*aws_base(cfg), "ec2", "disassociate-address", "--association-id", cfg.eip_association_id])
+    run(
+        [
+            *aws_base(cfg),
+            "ec2",
+            "create-tags",
+            "--resources",
+            cfg.old_instance_id,
+            "--tags",
+            f"Key=Name,Value={cfg.old_name_retired}",
+        ]
+    )
+    run(
+        [
+            *aws_base(cfg),
+            "ec2",
+            "create-tags",
+            "--resources",
+            cfg.new_instance_id,
+            "--tags",
+            f"Key=Name,Value={cfg.new_name_tag_final}",
+        ]
+    )
+    run(
+        [
+            *aws_base(cfg),
+            "ec2",
+            "associate-address",
+            "--allocation-id",
+            cfg.eip_allocation_id,
+            "--instance-id",
+            cfg.new_instance_id,
+        ]
+    )
+    log(f"EIP {cfg.eip_public_ip} now on NEW. Run: cutover post-start")
+
+
+def cmd_aws_rollback(cfg: Config, yes: bool) -> None:
+    confirm(f"Rollback EIP to OLD {cfg.old_instance_id}?", yes)
+    run(
+        [
+            *aws_base(cfg),
+            "ec2",
+            "associate-address",
+            "--allocation-id",
+            cfg.eip_allocation_id,
+            "--instance-id",
+            cfg.old_instance_id,
+        ]
+    )
+    run(
+        [
+            *aws_base(cfg),
+            "ec2",
+            "create-tags",
+            "--resources",
+            cfg.old_instance_id,
+            "--tags",
+            f"Key=Name,Value={cfg.old_name_tag}",
+        ]
+    )
+    log("Start services on OLD manually")
+
+
+def cmd_post_start(cfg: Config) -> None:
+    ip = cfg.eip_public_ip
+    run(ssh_cmd(cfg, f"sudo {cfg.validate_script} start-services", ip=ip))
+    run(ssh_cmd(cfg, f"sudo {cfg.validate_script} post-cutover", ip=ip))
+    run(ssh_cmd(cfg, "sudo setenforce 1; sudo restorecon -Rv /home /var/www /usr/local/directadmin", ip=ip), check=False)
+
+
+def cmd_deploy_scripts(cfg: Config) -> None:
+    require_root()
+    if not cfg.s3_bucket:
+        raise MigrationError("s3.bucket not configured")
+    for name in ("shrink-migration-validate.sh", "shrink-rsync-live.sh", "shrink_migration.py", "shrink-migration.config.yaml"):
+        src = f"s3://{cfg.s3_bucket}/{cfg.s3_prefix}/{name}"
+        dst = f"/usr/local/sbin/{name}" if name.endswith(".sh") else f"/usr/local/sbin/{name}"
+        if name.endswith(".yaml"):
+            dst = str(SCRIPT_DIR / name)
+        run([*aws_base(cfg), "s3", "cp", src, dst], check=False)
+    log("Deploy complete (upload scripts to S3 first from repo)")
+
+
+def cmd_cutover_final(cfg: Config, yes: bool) -> None:
+    """Full frozen cutover on OLD: stop -> final rsync -> pre-cutover gate."""
+    cmd_rsync(cfg, "final", yes)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="WBAT primary EBS shrink migration orchestrator",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=textwrap.dedent(
+            """
+            AM cutover (typical):
+              python3 shrink_migration.py cutover preflight
+              python3 shrink_migration.py cutover final --yes
+              python3 shrink_migration.py cutover boot-prep
+              # reboot NEW, verify SSH
+              python3 shrink_migration.py aws eip-flip --yes   # from laptop
+              python3 shrink_migration.py cutover post-start   # after EIP
+            """
+        ),
+    )
+    p.add_argument("--config", type=Path, default=DEFAULT_CONFIG, help="Path to YAML config")
+    p.add_argument("--yes", action="store_true", help="Skip interactive confirmation")
+    sub = p.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("status", help="Disk, SSH, rsync-diff summary")
+
+    v = sub.add_parser("validate", help="Run shrink-migration-validate.sh mode")
+    v.add_argument(
+        "mode",
+        choices=[
+            "stop-services",
+            "verify-stopped",
+            "rsync-diff",
+            "compare-counts",
+            "pre-cutover",
+            "post-rsync-new",
+            "post-cutover",
+            "start-services",
+        ],
+    )
+
+    r = sub.add_parser("rsync", help="Run rsync to NEW")
+    r.add_argument("phase", choices=["live", "final"], help="live=incremental; final=--delete after stop")
+
+    c = sub.add_parser("cutover", help="Cutover sub-steps")
+    csub = c.add_subparsers(dest="cutover_step", required=True)
+    csub.add_parser("preflight", help="rsync-diff + remote du")
+    csub.add_parser("final", help="stop services + final rsync + pre-cutover gate")
+    csub.add_parser("boot-prep", help="post-rsync-new + grub/dracut on NEW")
+    csub.add_parser("post-start", help="start-services + post-cutover after EIP")
+
+    aws = sub.add_parser("aws", help="AWS API steps (laptop or OLD with profile)")
+    asub = aws.add_subparsers(dest="aws_step", required=True)
+    asub.add_parser("fix-new-ssh", help="Reboot NEW + SSM restore SSH/sudoers")
+    asub.add_parser("eip-flip", help="Disassociate EIP from OLD, associate to NEW, DLM tags")
+    asub.add_parser("rollback", help="Reassociate EIP to OLD")
+
+    sub.add_parser("deploy", help="Pull scripts from S3 to /usr/local/sbin")
+
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    cfg = Config.load(args.config)
+
+    try:
+        if args.command == "status":
+            cmd_status(cfg)
+        elif args.command == "validate":
+            cmd_validate(cfg, args.mode)
+        elif args.command == "rsync":
+            cmd_rsync(cfg, args.phase, args.yes)
+        elif args.command == "cutover":
+            if args.cutover_step == "preflight":
+                cmd_cutover_preflight(cfg)
+            elif args.cutover_step == "final":
+                cmd_cutover_final(cfg, args.yes)
+            elif args.cutover_step == "boot-prep":
+                cmd_cutover_boot_prep(cfg)
+            elif args.cutover_step == "post-start":
+                cmd_post_start(cfg)
+        elif args.command == "aws":
+            if args.aws_step == "fix-new-ssh":
+                cmd_aws_fix_new_ssh(cfg, args.yes)
+            elif args.aws_step == "eip-flip":
+                cmd_aws_eip_flip(cfg, args.yes)
+            elif args.aws_step == "rollback":
+                cmd_aws_rollback(cfg, args.yes)
+        elif args.command == "deploy":
+            cmd_deploy_scripts(cfg)
+        else:
+            raise MigrationError(f"Unknown command: {args.command}")
+    except MigrationError as exc:
+        log(f"ERROR: {exc}")
+        return 1
+    except subprocess.CalledProcessError as exc:
+        log(f"ERROR: command failed with exit {exc.returncode}")
+        return exc.returncode
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Aligns Terraform with the **completed primary EBS shrink** (600 GB → 200 GB via new instance + EIP cutover on **2026-06-30**). Also brings both pet servers' root `volume_size` under explicit management and adds reusable migration scripts.

### Terraform

- **Primary import** → `i-0118b8ede80b52ef7` (replaces `i-0572702f0a58f6dcd` in state)
- **`volume_size = 200`** on `aws_instance.primary` (`vol-0e779cc0687ffc92c`)
- **`ebs_optimized = false`** — matches the cutover instance; `true` forced replacement on apply
- **New `aws_eip` + `aws_eip_association`** for primary and secondary, with import blocks
- **Secondary** `volume_size = 200` — explicit management, no-op to live volume
- **Snapshot filter** stays at `volume-size = 300` (2023 baseline tag); do not change until a 200 GB DLM baseline exists

### Migration scripts (`scripts/`)

| File | Purpose |
|------|---------|
| `shrink_migration.py` | Cutover orchestrator (rsync, EIP flip, validation) |
| `shrink-migration.config.yaml` | Instance IDs, IPs, EIP, rsync excludes |
| `shrink-migration-validate.sh` | Pre/post-cutover gates |
| `shrink-rsync-live.sh` | Standalone rsync helper |
| `shrink-cleanup-old.sh` | Terminate retired primary after 7-day bake |

Retired primary (`i-0572702f0a58f6dcd` / `vol-0d5064ffa1256b9fa`) is **not** in Terraform — keep for rollback until ~**2026-07-07**, then run `scripts/shrink-cleanup-old.sh --yes`.

## Live state (post-cutover)

| Resource | ID |
|----------|-----|
| Production primary | `i-0118b8ede80b52ef7` @ `172.30.0.71` |
| Root volume | `vol-0e779cc0687ffc92c` (200 GB) |
| Primary EIP | `44.214.133.234` / `eipalloc-0e4834de5c1e13061` |
| Retired (rollback) | `i-0572702f0a58f6dcd` / `vol-0d5064ffa1256b9fa` |

## TFC apply notes

Before apply, remove stale primary from state (EIPs were not yet in state):

```bash
terraform state rm 'module.us-east-1.module.ec2.aws_instance.primary'
```

**Verified safe plan** (no instance/EIP replacement):

- Import `aws_instance.primary`, EIPs, and EIP associations
- In-place: `disable_api_termination = true`, `volume_tags`, EIP standard tags
- EIP association stays on `i-0118b8ede80b52ef7`

After successful apply: comment out import blocks in `aws/imports.tf` per repo convention.

## Context

This branch started as “manage volume size without growth” after DirectAdmin backups moved to S3 (#60). We instead executed **Option 1**: rsync to a new 200 GB instance, EIP flip, and post-cutover DirectAdmin/nginx IP fix (`172.30.0.87` → `172.30.0.71`).

## Test plan

- [x] TFC plan: imports succeed; no replacement of `aws_instance.primary` or EIPs
- [ ] TFC apply completes cleanly
- [ ] Post-apply plan is no-op (or tag-only)
- [ ] Comment out import blocks in `aws/imports.tf`
- [ ] `www.tellerstech.com` / `shipitweekly.fm` via CloudFront
- [ ] DLM snapshots new primary on next Mon/Wed/Fri run
- [ ] After 7-day bake (~2026-07-07): `scripts/shrink-cleanup-old.sh --yes`