### PR TITLE
feat(s3): add S3 bucket + IAM user for DirectAdmin remote backups

### DIFF
--- a/aws/global/outputs.tf
+++ b/aws/global/outputs.tf
@@ -39,3 +39,14 @@ output "briefs_bucket_arn" {
   value       = aws_s3_bucket.briefs.arn
   description = "ARN of the briefs backup bucket (for IAM)."
 }
+
+# S3 DirectAdmin backups
+output "directadmin_backups_bucket_id" {
+  value       = aws_s3_bucket.directadmin_backups.id
+  description = "S3 bucket for DirectAdmin Enhanced Backups; configure this bucket name in DA."
+}
+
+output "directadmin_backup_iam_user" {
+  value       = aws_iam_user.directadmin_backup.name
+  description = "IAM user DirectAdmin uses for S3 backups; create an access key for it and paste into DA."
+}

--- a/aws/global/s3-directadmin-backups.tf
+++ b/aws/global/s3-directadmin-backups.tf
@@ -1,0 +1,146 @@
+# S3 bucket + IAM user for DirectAdmin remote (Enhanced) backups.
+#
+# DirectAdmin can write backups straight to S3 (Admin Tools -> Enhanced
+# Backups, storage type "S3") using these credentials - no s3fs / FUSE mount
+# required. Configure DA with:
+#   - Endpoint/Region: us-east-1
+#   - Bucket:          aws_s3_bucket.directadmin_backups.id (see output below)
+#   - Access key:      created out-of-band for the IAM user below (see note)
+#
+# Goal: stop storing 390+ GB of weekly backups on the Main server's root EBS
+# volume. Keep only a small local working set in DA; retain history in S3 where
+# lifecycle rules tier it to cheaper storage and expire it automatically.
+
+resource "aws_s3_bucket" "directadmin_backups" {
+  bucket = "wbat-tellerstech-directadmin-backups-${data.aws_caller_identity.current.account_id}"
+
+  tags = merge(
+    var.core_tags,
+    {
+      "Name"     = "tellerstech-directadmin-backups"
+      "scm:file" = "aws/global/s3-directadmin-backups.tf"
+    },
+  )
+}
+
+resource "aws_s3_bucket_versioning" "directadmin_backups" {
+  bucket = aws_s3_bucket.directadmin_backups.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "directadmin_backups" {
+  bucket = aws_s3_bucket.directadmin_backups.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "directadmin_backups" {
+  bucket = aws_s3_bucket.directadmin_backups.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# Retention / cost control. Recent backups stay instantly retrievable; older
+# ones tier down and eventually expire. DirectAdmin's own retention still
+# governs how many objects exist; this is the cost + cleanup backstop.
+resource "aws_s3_bucket_lifecycle_configuration" "directadmin_backups" {
+  bucket = aws_s3_bucket.directadmin_backups.id
+
+  rule {
+    id     = "tier-and-expire-backups"
+    status = "Enabled"
+
+    filter {}
+
+    transition {
+      days          = 30
+      storage_class = "STANDARD_IA"
+    }
+
+    transition {
+      days          = 90
+      storage_class = "GLACIER_IR" # Glacier Instant Retrieval - no restore delay
+    }
+
+    expiration {
+      days = 365
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
+}
+
+# Dedicated IAM user for DirectAdmin, scoped to only this bucket.
+resource "aws_iam_user" "directadmin_backup" {
+  name          = "directadmin-backup"
+  force_destroy = false
+
+  tags = merge(
+    var.core_tags,
+    {
+      "scm:file" = "aws/global/s3-directadmin-backups.tf"
+    },
+  )
+}
+
+resource "aws_iam_user_policy" "directadmin_backup" {
+  name = "directadmin-backup-s3"
+  user = aws_iam_user.directadmin_backup.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "ListBucket"
+        Effect = "Allow"
+        Action = [
+          "s3:ListBucket",
+          "s3:GetBucketLocation",
+          "s3:ListBucketMultipartUploads",
+        ]
+        Resource = aws_s3_bucket.directadmin_backups.arn
+      },
+      {
+        Sid    = "ReadWriteObjects"
+        Effect = "Allow"
+        Action = [
+          "s3:PutObject",
+          "s3:GetObject",
+          "s3:DeleteObject",
+          "s3:AbortMultipartUpload",
+          "s3:ListMultipartUploadParts",
+        ]
+        Resource = "${aws_s3_bucket.directadmin_backups.arn}/*"
+      },
+    ]
+  })
+}
+
+# NOTE: The access key is intentionally NOT managed by Terraform (matches the
+# pattern used for the TerraformCloud user, and keeps the secret out of state).
+# Create it once and paste into DirectAdmin:
+#
+#   aws iam create-access-key --user-name directadmin-backup --profile wbat
+#
+# If you would rather have Terraform manage it, uncomment the block below and
+# read the secret with: terraform output -raw directadmin_backup_secret_key
+#
+# resource "aws_iam_access_key" "directadmin_backup" {
+#   user = aws_iam_user.directadmin_backup.name
+# }


### PR DESCRIPTION
## Summary
Moves DirectAdmin backups off the Main server's root EBS volume and into S3, so weekly backups stop filling the disk.

- New S3 bucket `wbat-tellerstech-directadmin-backups-<account_id>` with versioning, AES256 SSE, and full public-access block (mirrors the existing `s3-briefs` bucket).
- **Lifecycle/retention** rules as a cost + cleanup backstop: `STANDARD_IA` at 30d, `GLACIER_IR` at 90d, expire at 365d, noncurrent-version expire at 30d, abort incomplete multipart uploads at 7d.
- Dedicated least-privilege IAM user `directadmin-backup`, scoped to only this bucket (List + Get/Put/Delete object + multipart).
- Outputs for the bucket name and IAM user name to make DA setup easy.

## Why
Investigation of `server.wbat.net` (Main) found the 600 GB root volume at 100%. The dominant consumers were:
- `/home/backup` — **393 GB** of weekly DirectAdmin backups with no off-host retention.
- `/home/ec2-user` — ~91 GB of **March/April 2023 account-migration tarballs** (already removed; ~26 GB physically reclaimed due to XFS reflink sharing, disk now at 96%).

DirectAdmin's **Enhanced Backups** support S3 destinations natively (no s3fs/FUSE). Pointing DA at this bucket lets us keep only a small local working set and retain history cheaply in S3.

## Follow-up (manual, after merge/apply)
1. Create an access key for the IAM user and paste into DirectAdmin:
   ```bash
   aws iam create-access-key --user-name directadmin-backup --profile wbat
   ```
   (Or uncomment the `aws_iam_access_key` block to let Terraform manage it.)
2. In DA: Admin Tools -> Enhanced Backups -> add an **S3** storage destination (region `us-east-1`, the bucket from `directadmin_backups_bucket_id`, the access key/secret), set local retention low, and point the schedule at S3.
3. Once verified, prune `/home/backup` history on the server.

## Notes
- Access key is intentionally **not** in state (matches the TerraformCloud user pattern).
- Separate from #59 (EBS volume increase). With backups in S3 + the 2023 tarballs gone, the 800 GB EBS bump in #59 may no longer be strictly necessary — your call whether to still apply it for headroom.

## Test plan
- [ ] `terraform plan` shows only new S3 bucket + bucket sub-resources + IAM user/policy (no changes to existing resources).
- [ ] Apply succeeds; `terraform output directadmin_backups_bucket_id` returns the bucket.
- [ ] DA test backup to S3 succeeds and lands an object.
- [ ] Lifecycle transitions visible in S3 console after apply.

Made with [Cursor](https://cursor.com)