### PR TITLE
chore(dlm): reduce EBS snapshot retention to 3

### DIFF
--- a/aws/docs/cost-optimization-checklist.md
+++ b/aws/docs/cost-optimization-checklist.md
@@ -99,7 +99,7 @@ ps aux --sort=-%mem | head -10
 | EC2 Secondary | ~$14 | ~$14 |
 | EBS storage | ~$8-16 | ~$8-16 |
 | CloudFront | ~$0-5 | ~$0-5 |
-| Snapshots (6x) | ~$2-5 | ~$2-5 |
+| Snapshots (3x DLM + permanent) | ~$2-5 | ~$2-5 |
 | **Total** | **~$78-94** | **~$51-67** |
 
 **Potential savings: ~$27/month ($324/year)**

--- a/aws/us-east-1/ec2/primary-lifecycle_manager.tf
+++ b/aws/us-east-1/ec2/primary-lifecycle_manager.tf
@@ -3,6 +3,10 @@ resource "aws_dlm_lifecycle_policy" "primary" {
   execution_role_arn = data.aws_iam_role.AWSDataLifecycleManagerDefaultRole.arn
   state              = "ENABLED"
 
+  # Retain 3 rolling DLM snapshots per instance. Permanent one-offs are NOT managed
+  # by DLM (no dlm:managed tag), e.g. primary-pre-shrink-cutover, 12/31/25 backup,
+  # Primary 2024/06/26, WBAT Primary Server - First (snap-0912039f0af4e12ed).
+
   policy_details {
     resource_types = ["INSTANCE"]
 
@@ -19,7 +23,7 @@ resource "aws_dlm_lifecycle_policy" "primary" {
       }
 
       retain_rule {
-        count = 6
+        count = 3
       }
 
       tags_to_add = {

--- a/aws/us-east-1/ec2/secondary-lifecycle_manager.tf
+++ b/aws/us-east-1/ec2/secondary-lifecycle_manager.tf
@@ -3,6 +3,9 @@ resource "aws_dlm_lifecycle_policy" "secondary" {
   execution_role_arn = data.aws_iam_role.AWSDataLifecycleManagerDefaultRole.arn
   state              = "ENABLED"
 
+  # Retain 3 rolling DLM snapshots per instance. WBAT Secondary Server - First
+  # (snap-0b6b6f6a5ffa9af99) is kept outside DLM (dlm:managed tag removed).
+
   policy_details {
     resource_types = ["INSTANCE"]
 
@@ -19,7 +22,7 @@ resource "aws_dlm_lifecycle_policy" "secondary" {
       }
 
       retain_rule {
-        count = 6
+        count = 3
       }
 
       tags_to_add = {


### PR DESCRIPTION
## Summary
- Reduce DLM retain count from **6 → 3** for primary and secondary instance snapshot policies.
- Document permanent snapshots kept outside DLM (pre-shrink cutover, 12/31/25, 2024/06/26, and First snapshots).
- Update cost checklist snapshot line to reflect 3 rolling + permanent keepers.

## Ops already done (outside Terraform)
- Deleted 6 unnamed 2024 snapshots from stopped backup instance `i-04979751f5ae9d25c`.
- Pruned excess DLM rolling snapshots beyond 3 on OLD primary and secondary.
- Removed `dlm:managed` from **First** snapshots and tagged permanent keepers with `retain=permanent`.

## Protected snapshots (not managed by DLM)
| Snapshot ID | Name |
|---|---|
| snap-0c562aad0c3c6b51f | primary-pre-shrink-cutover |
| snap-04a52e9b7e796c320 | WBAT Primary Server - Backup 12/31/25 |
| snap-08a301d8607d04bd3 | Primary - 2024/06/26 02:29 GMT-4 |
| snap-0912039f0af4e12ed | WBAT Primary Server - First |
| snap-0b6b6f6a5ffa9af99 | WBAT Secondary Server - First |

## Test plan
- [ ] TFC plan shows only DLM policy `retain_rule.count` change (primary + secondary)
- [ ] TFC apply succeeds
- [ ] After next DLM run, verify ≤3 rolling snapshots per active instance
- [ ] Confirm permanent snapshots still present and untagged `dlm:managed`


Made with [Cursor](https://cursor.com)