### PR TITLE
feat(scripts): add DirectAdmin S3 backup hooks for server and server2

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -11,6 +11,7 @@ Optional operational tooling for **EC2 root-volume shrink** via rsync and Elasti
 | [`shrink-migration-validate.sh`](shrink-migration-validate.sh) | Validation gates (rsync-diff, pre/post-cutover, services) |
 | [`shrink-rsync-live.sh`](shrink-rsync-live.sh) | Standalone incremental rsync helper |
 | [`shrink-cleanup-old.sh`](shrink-cleanup-old.sh) | Post-bake cleanup of retired source instance and volume |
+| [`directadmin/`](directadmin/) | DA post-backup hooks: admin + system backups → S3, local cleanup |
 
 ## Setup
 

--- a/scripts/directadmin/README.md
+++ b/scripts/directadmin/README.md
@@ -1,0 +1,49 @@
+# DirectAdmin backup hooks (server install)
+
+Install on **both** DirectAdmin servers (`server` and `server2`) under `/usr/local/directadmin/scripts/custom/`.
+
+## Hooks
+
+| File | DirectAdmin event |
+|------|-------------------|
+| `all_backups_post.sh` | After **Admin Backup** (`.tar.zst` or `.tar.gz` under `/home/admin_backups`) |
+| `system_backup_post.sh` | After **System Backup** (`apache/`, `bind/`, `custom/`, `mysql/` under `/home/backup/MM-DD-YY/`) |
+
+Both upload to `s3://wbat-tellerstech-directadmin-backups-<account>/<hostname>/YYYY-MM-DD/` (e.g. `server/` or `server2/`) via rclone remote `s3backup`, then **delete local copies** after a successful upload.
+
+## Install / update on server
+
+```bash
+install -m 700 scripts/directadmin/all_backups_post.sh \
+  /usr/local/directadmin/scripts/custom/all_backups_post.sh
+install -m 700 scripts/directadmin/system_backup_post.sh \
+  /usr/local/directadmin/scripts/custom/system_backup_post.sh
+```
+
+Requires root rclone config at `/root/.config/rclone/rclone.conf` with `s3backup` remote and `no_check_bucket = true`.
+
+`/home/admin_backups` must be mode **711** (`drwx--x--x`) so per-user backup staging dirs are reachable. If it is `700`, DirectAdmin logs `create_backup_domain_dir: ... did not exist` and backups produce nothing to upload.
+
+On **server2**, also confirm `backup_crons.list` uses `when=cron` (not `when=now`) so the Wed 5:30 AM schedule keeps firing.
+
+## S3 retention
+
+Objects are **not** deleted immediately after upload. The bucket lifecycle (Terraform `s3-directadmin-backups.tf`) tiers to STANDARD_IA / GLACIER_IR and **expires at 365 days**.
+
+## One-time catch-up (already on disk)
+
+```bash
+/usr/local/directadmin/scripts/custom/all_backups_post.sh
+tail -30 /var/log/da-backup-s3.log
+df -h /
+```
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| S3 only has `hook-test.txt` or tiny files | `/home/admin_backups` is `700` | `chmod 711 /home/admin_backups` |
+| `create_backup_domain_dir: ... did not exist` in `errortaskq.log` | Same permission issue | `chmod 711` and re-run backup from DA UI |
+| Hook never runs for system backups | Missing `system_backup_post.sh` | Install both hook scripts (see above) |
+| Nothing new in S3 after schedule | `backup_crons.list` has `when=now` | Set `when=cron` to match `server` |
+| Upload works but local disk stays full | Old stub hook (no cleanup) | Deploy current `all_backups_post.sh` from this repo |

--- a/scripts/directadmin/all_backups_post.sh
+++ b/scripts/directadmin/all_backups_post.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# DirectAdmin post-backup hook: upload admin + system backups to S3, then free local disk.
+# Install: /usr/local/directadmin/scripts/custom/all_backups_post.sh
+# Also symlink or copy to system_backup_post.sh so system backups trigger the same upload.
+set -euo pipefail
+
+ADMIN_DIR="/home/admin_backups"
+SYSTEM_ROOT="/home/backup"
+BUCKET="wbat-tellerstech-directadmin-backups-708113892725"
+HOST="$(hostname -s)"
+DATE="$(date +%F)"
+DEST="s3backup:${BUCKET}/${HOST}/${DATE}/"
+LOG="/var/log/da-backup-s3.log"
+
+RCLONE_OPTS=(
+  --s3-no-check-bucket
+  --checksum
+  --transfers 4
+  --checkers 8
+  --log-file "$LOG"
+  --log-level INFO
+)
+
+log() { echo "$(date -Iseconds) $*" >>"$LOG"; }
+
+upload_admin() {
+  [[ -d "$ADMIN_DIR" ]] || return 0
+  local count
+  count="$(find "$ADMIN_DIR" \( -name '*.tar.zst' -o -name '*.tar.gz' \) -type f 2>/dev/null | wc -l)"
+  [[ "$count" -gt 0 ]] || return 0
+  log "upload admin_backups ($count archive files) -> $DEST"
+  rclone copy "$ADMIN_DIR" "$DEST" "${RCLONE_OPTS[@]}"
+}
+
+upload_system() {
+  [[ -d "$SYSTEM_ROOT" ]] || return 0
+  local sys_dir="${SYSTEM_ROOT}/$(date +%m-%d-%y)"
+  if [[ ! -d "$sys_dir" ]]; then
+    sys_dir="$(find "$SYSTEM_ROOT" -mindepth 1 -maxdepth 1 -type d -printf '%T@ %p\n' 2>/dev/null | sort -n | tail -1 | cut -d' ' -f2- || true)"
+  fi
+  [[ -n "${sys_dir:-}" && -d "$sys_dir" ]] || return 0
+  log "upload system backup $sys_dir -> $DEST"
+  rclone copy "$sys_dir" "$DEST" "${RCLONE_OPTS[@]}"
+}
+
+cleanup_admin_local() {
+  [[ -d "$ADMIN_DIR" ]] || return 0
+  find "$ADMIN_DIR" \( -name '*.tar.zst' -o -name '*.tar.gz' \) -type f -delete
+  find "$ADMIN_DIR" -mindepth 1 -maxdepth 1 -type d ! -name '.*' -exec rm -rf {} +
+  log "cleaned local $ADMIN_DIR (tar.zst + staging subdirs)"
+}
+
+cleanup_system_local() {
+  [[ -d "$SYSTEM_ROOT" ]] || return 0
+  local sys_dir="${SYSTEM_ROOT}/$(date +%m-%d-%y)"
+  [[ -d "$sys_dir" ]] && rm -rf "$sys_dir"
+  find "$SYSTEM_ROOT" -mindepth 1 -maxdepth 1 -type d -mtime +7 -exec rm -rf {} +
+  log "cleaned local system backup dirs under $SYSTEM_ROOT"
+}
+
+upload_admin
+upload_system
+cleanup_admin_local
+cleanup_system_local

--- a/scripts/directadmin/system_backup_post.sh
+++ b/scripts/directadmin/system_backup_post.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# DirectAdmin post-hook for System Backup (apache/bind/custom/mysql under /home/backup).
+# Reuses the same S3 upload + local cleanup as admin backups.
+exec /usr/local/directadmin/scripts/custom/all_backups_post.sh


### PR DESCRIPTION
## Summary
- Add canonical DirectAdmin post-backup hooks (`all_backups_post.sh`, `system_backup_post.sh`) that rclone admin/system backups to S3 and clean up local disk after a successful upload.
- Document install steps, rclone requirements, and the `711` permission requirement on `/home/admin_backups` (the root cause of server2 only uploading `hook-test.txt`).
- Link the new `scripts/directadmin/` folder from `scripts/README.md`.

## Context
`server` was backing up correctly; `server2` had an old stub hook, missing `system_backup_post.sh`, and `/home/admin_backups` mode `700` (should be `711`). Fixes were applied live on server2; this PR commits the repo copy so both hosts stay in sync.

## Test plan
- [x] Verified hook uploads to `s3://wbat-tellerstech-directadmin-backups-708113892725/server2/<date>/` on server2 after fix
- [ ] After merge, confirm both servers match repo scripts: `diff` against `/usr/local/directadmin/scripts/custom/all_backups_post.sh`
- [ ] Confirm next scheduled admin backup (Wed 5:30 AM) populates S3 under `server2/` with full archives, not just test files
- [ ] `tail -30 /var/log/da-backup-s3.log` shows archive upload + local cleanup on both hosts


Made with [Cursor](https://cursor.com)