### PR TITLE
chore(ci): stable GitHub Actions check names (step 1/4)

### DIFF
--- a/.github/workflows/terraform_ci.yml
+++ b/.github/workflows/terraform_ci.yml
@@ -6,15 +6,11 @@ jobs:
   format:
     name: Format
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        terraform_version:
-          - "~1.14"
     steps:
       - uses: actions/checkout@v4
       - uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: ${{ matrix.terraform_version }}
+          terraform_version: "~1.14"
 
       - name: Terraform fmt
         id: fmt
@@ -22,12 +18,10 @@ jobs:
         working-directory: ./
 
   validate:
-    name: Validate
+    name: Validate (${{ matrix.workspaces }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        terraform_version:
-          - "~1.14"
         workspaces:
           - aws
           - github
@@ -37,7 +31,7 @@ jobs:
 
       - uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: ${{ matrix.terraform_version }}
+          terraform_version: "~1.14"
           cli_config_credentials_hostname: app.terraform.io
           cli_config_credentials_token: ${{ secrets.TFC_API_TOKEN }}
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Brownfield resources are imported via blocks in [`aws/imports.tf`](aws/imports.t
 | Document | Description |
 |----------|-------------|
 | [CloudFront 502 troubleshooting](aws/docs/cloudfront-tellerstech-502-troubleshooting.md) | Origin connectivity and CloudFront error diagnosis |
+| [Terraform version upgrade](aws/docs/terraform-version-upgrade.md) | Incremental HCP Terraform / CI version bump process |
 | [Cost optimization checklist](aws/docs/cost-optimization-checklist.md) | EC2 sizing and cost review notes |
 | [Migration scripts](scripts/README.md) | Optional EC2 root-volume shrink tooling |
 

--- a/aws/docs/terraform-version-upgrade.md
+++ b/aws/docs/terraform-version-upgrade.md
@@ -1,0 +1,28 @@
+# Terraform version upgrades
+
+HCP Terraform and this repo are upgraded in **small PRs** so branch protection and workspace pins do not block each other.
+
+## Current targets
+
+| Layer | Version |
+|-------|---------|
+| HCP Terraform workspaces | 1.14.3 (see `tfc/tfc-workspace-*.tf`) |
+| GitHub Actions CI | ~1.14 |
+| `required_version` in workspace `versions.tf` | >= 1.10 |
+
+## Incremental upgrade to 1.15.7
+
+Merge in order:
+
+1. **Stable CI check names** — Remove Terraform version from GitHub Actions matrix job names (`Format`, `Validate (aws)`, …). Future TF bumps no longer require branch-protection renames. *May need one admin merge bypass while `main` still lists old `~1.14` check names.*
+2. **Tooling 1.15** — Bump CI/Infracost to `~1.15`, `required_version` to `>= 1.15.0`, add `.terraform-version`, update README. No TFC or branch-protection changes.
+3. **HCP Terraform 1.15.7** — Set `local.terraform_version` in `tfc/locals.tf` and apply via `wbat-terraform-tfc`.
+
+After step 3, apply `wbat-terraform-github` if step 1 updated required status checks (step 1 includes that change).
+
+## Local validation
+
+```bash
+terraform version   # or use .terraform-version with tfenv/asdf after step 2
+cd aws && terraform init -backend=false && terraform validate
+```


### PR DESCRIPTION
## Summary
Step **1 of 4** in the [incremental Terraform 1.15 upgrade](aws/docs/terraform-version-upgrade.md).

- Remove `terraform_version` from the CI matrix so check names stay **`Format`** and **`Validate (aws|github|tfc)`** instead of embedding `~1.14` in every job name.
- Still runs Terraform **~1.14** — no HCP workspace or `required_version` changes yet.
- Adds `aws/docs/terraform-version-upgrade.md` with the full merge order.

## Merge note
`main` branch protection still requires the old `Format (~1.14)` checks until **PR 2** lands. This PR may need an **admin merge bypass** once CI is green.

## Follow-ups
- **PR 2**: Update `github/repos/wbat-terraform.tf` required status checks
- **PR 3**: Bump CI/Infracost/`required_version`/`.terraform-version` to 1.15
- **PR 4**: Pin HCP Terraform workspaces to 1.15.7

## Test plan
- [ ] CI reports `Format` and `Validate (aws|github|tfc)` on this PR
- [ ] Merge with admin bypass if branch protection blocks on old check names


Made with [Cursor](https://cursor.com)