### PR TITLE
chore(github): stable branch protection checks (step 2/4)

### DIFF
--- a/github/repos/wbat-terraform.tf
+++ b/github/repos/wbat-terraform.tf
@@ -39,11 +39,11 @@ resource "github_branch_protection" "wbat-terraform-main" {
       "Terraform Cloud/WBAT/wbat-terraform-github",
       "Terraform Cloud/WBAT/wbat-terraform-tfc",
 
-      # Github Actions
-      "Format (~1.14)",
-      "Validate (~1.14, aws)",
-      "Validate (~1.14, github)",
-      "Validate (~1.14, tfc)",
+      # Github Actions (version-independent names; see aws/docs/terraform-version-upgrade.md)
+      "Format",
+      "Validate (aws)",
+      "Validate (github)",
+      "Validate (tfc)",
     ]
     strict = true
   }


### PR DESCRIPTION
## Summary
Step **2 of 4** — depends on **#67** merging first (or stack-merge with it).

Updates `github/repos/wbat-terraform.tf` required status checks to match the stable CI names from step 1:
- `Format`
- `Validate (aws)`, `Validate (github)`, `Validate (tfc)`

## Merge order
1. Merge **#67** (CI stable names) — may need admin bypass once
2. Merge **this PR** — apply via `wbat-terraform-github`
3. Then **#68** (tooling 1.15) and **#69** (TFC pins)

## Test plan
- [ ] After #67 merges, this PR shows green `Format` + `Validate (*)` checks
- [ ] After merge + `wbat-terraform-github` apply, `main` protection lists new check names


Made with [Cursor](https://cursor.com)