### PR TITLE
chore(tfc): pin HCP Terraform workspaces to 1.15.7 (step 4/4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ flowchart LR
 
 ## Prerequisites
 
-- [Terraform](https://developer.hashicorp.com/terraform/install) **≥ 1.15.0** (CI uses **~1.15**; HCP pins in a follow-up PR)
+- [Terraform](https://developer.hashicorp.com/terraform/install) **≥ 1.15.0** (CI and HCP Terraform use **1.15.7**)
 - Access to the **HCP Terraform** organization for plan/apply
 - AWS credentials via HCP Terraform role assumption — **no long-lived access keys in this repository**
 

--- a/aws/docs/terraform-version-upgrade.md
+++ b/aws/docs/terraform-version-upgrade.md
@@ -6,7 +6,7 @@ HCP Terraform and this repo are upgraded in **small PRs** so branch protection a
 
 | Layer | Version |
 |-------|---------|
-| HCP Terraform workspaces | 1.14.3 (see `tfc/tfc-workspace-*.tf`) |
+| HCP Terraform workspaces | **1.15.7** (after step 4) |
 | GitHub Actions CI | ~1.15 (after step 3) |
 | `required_version` in workspace `versions.tf` | >= 1.15.0 (after step 3) |
 

--- a/tfc/locals.tf
+++ b/tfc/locals.tf
@@ -1,4 +1,5 @@
 locals {
+  terraform_version = "1.15.7"
 
   tfc-workspace_ids = [
     tfe_workspace.aws.id,

--- a/tfc/tfc-workspace-aws.tf
+++ b/tfc/tfc-workspace-aws.tf
@@ -6,7 +6,7 @@ resource "tfe_workspace" "aws" {
   auto_apply     = false
   queue_all_runs = false
 
-  terraform_version     = "1.14.3"
+  terraform_version     = local.terraform_version
   working_directory     = "aws"
   file_triggers_enabled = true
   trigger_patterns      = ["/aws/**", "/aws/**/*"]

--- a/tfc/tfc-workspace-github.tf
+++ b/tfc/tfc-workspace-github.tf
@@ -6,7 +6,7 @@ resource "tfe_workspace" "github" {
   auto_apply     = false
   queue_all_runs = false
 
-  terraform_version     = "1.14.3"
+  terraform_version     = local.terraform_version
   working_directory     = "github"
   file_triggers_enabled = true
   trigger_patterns      = ["/github/**", "/github/**/*"]

--- a/tfc/tfc-workspace-tfc.tf
+++ b/tfc/tfc-workspace-tfc.tf
@@ -6,7 +6,7 @@ resource "tfe_workspace" "tfc" {
   auto_apply     = false
   queue_all_runs = false
 
-  terraform_version     = "1.14.3"
+  terraform_version     = local.terraform_version
   working_directory     = "tfc"
   file_triggers_enabled = true
   trigger_patterns      = ["/tfc/**", "/tfc/**/*"]


### PR DESCRIPTION
## Summary
Step **4 of 4** — stacks on **#69** (tooling 1.15).

- `local.terraform_version = "~> 1.15.0"` in `tfc/locals.tf`
- All three `tfe_workspace` resources use `local.terraform_version` (HCP picks newest 1.15.x)

## Apply order after merge
1. **`wbat-terraform-tfc`** — updates Terraform version on all HCP workspaces
2. **`wbat-terraform-aws`** / **`wbat-terraform-github`** — next runs use matching 1.15.x automatically

## Merge order
Merge **#67 → #68 → #69 → this PR** (or merge the stack once earlier steps are on `main`).

Closes the [incremental upgrade](aws/docs/terraform-version-upgrade.md). Supersedes the monolithic #66.

## Test plan
- [ ] `wbat-terraform-tfc` plan shows `terraform_version` change only (no resource churn)
- [ ] After apply, HCP UI shows a 1.15.x version for all three workspaces
- [ ] Speculative plans succeed on aws/github workspaces