### PR TITLE
chore(tfc): set HCP workspace Terraform version to ~> 1.15.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ flowchart LR
 
 ## Prerequisites
 
-- [Terraform](https://developer.hashicorp.com/terraform/install) **≥ 1.15.0** (CI uses **~1.15**; HCP pins in a follow-up PR)
+- [Terraform](https://developer.hashicorp.com/terraform/install) **≥ 1.15.0** (CI uses **~1.15**; HCP workspaces use **~> 1.15.0**)
 - Access to the **HCP Terraform** organization for plan/apply
 - AWS credentials via HCP Terraform role assumption — **no long-lived access keys in this repository**
 

--- a/aws/docs/terraform-version-upgrade.md
+++ b/aws/docs/terraform-version-upgrade.md
@@ -6,7 +6,7 @@ HCP Terraform and this repo are upgraded in **small PRs** so branch protection a
 
 | Layer | Version |
 |-------|---------|
-| HCP Terraform workspaces | 1.14.3 (see `tfc/tfc-workspace-*.tf`) |
+| HCP Terraform workspaces | `~> 1.15.0` (see `tfc/locals.tf`) |
 | GitHub Actions CI | ~1.15 (after step 3) |
 | `required_version` in workspace `versions.tf` | >= 1.15.0 (after step 3) |
 
@@ -16,7 +16,7 @@ Merge in order:
 
 1. **Stable CI check names** — Remove Terraform version from GitHub Actions matrix job names (`Format`, `Validate (aws)`, …). Future TF bumps no longer require branch-protection renames. *May need one admin merge bypass while `main` still lists old `~1.14` check names.*
 2. **Tooling 1.15** — Bump CI/Infracost to `~1.15`, `required_version` to `>= 1.15.0`, add `.terraform-version`, update README. No TFC or branch-protection changes.
-3. **HCP Terraform 1.15.7** — Set `local.terraform_version` in `tfc/locals.tf` and apply via `wbat-terraform-tfc`.
+3. **HCP Terraform ~> 1.15.0** — Set `local.terraform_version = "~> 1.15.0"` in `tfc/locals.tf` and apply via `wbat-terraform-tfc`.
 
 After step 3, apply `wbat-terraform-github` if step 1 updated required status checks (step 1 includes that change).
 

--- a/tfc/locals.tf
+++ b/tfc/locals.tf
@@ -1,4 +1,5 @@
 locals {
+  terraform_version = "~> 1.15.0"
 
   tfc-workspace_ids = [
     tfe_workspace.aws.id,

--- a/tfc/tfc-workspace-aws.tf
+++ b/tfc/tfc-workspace-aws.tf
@@ -6,7 +6,7 @@ resource "tfe_workspace" "aws" {
   auto_apply     = false
   queue_all_runs = false
 
-  terraform_version     = "1.14.3"
+  terraform_version     = local.terraform_version
   working_directory     = "aws"
   file_triggers_enabled = true
   trigger_patterns      = ["/aws/**", "/aws/**/*"]

--- a/tfc/tfc-workspace-github.tf
+++ b/tfc/tfc-workspace-github.tf
@@ -6,7 +6,7 @@ resource "tfe_workspace" "github" {
   auto_apply     = false
   queue_all_runs = false
 
-  terraform_version     = "1.14.3"
+  terraform_version     = local.terraform_version
   working_directory     = "github"
   file_triggers_enabled = true
   trigger_patterns      = ["/github/**", "/github/**/*"]

--- a/tfc/tfc-workspace-tfc.tf
+++ b/tfc/tfc-workspace-tfc.tf
@@ -6,7 +6,7 @@ resource "tfe_workspace" "tfc" {
   auto_apply     = false
   queue_all_runs = false
 
-  terraform_version     = "1.14.3"
+  terraform_version     = local.terraform_version
   working_directory     = "tfc"
   file_triggers_enabled = true
   trigger_patterns      = ["/tfc/**", "/tfc/**/*"]


### PR DESCRIPTION
## Summary
Updates all three HCP Terraform workspaces from pinned **1.14.3** to **`~> 1.15.0`** via `local.terraform_version` in `tfc/locals.tf`.

HCP automatically selects the newest 1.15.x release that satisfies the constraint.

| Workspace | Before | After |
|-----------|--------|-------|
| `wbat-terraform-aws` | `1.14.3` | `local.terraform_version` → `~> 1.15.0` |
| `wbat-terraform-github` | `1.14.3` | same |
| `wbat-terraform-tfc` | `1.14.3` | same |

Completes step 4 of [terraform-version-upgrade.md](aws/docs/terraform-version-upgrade.md) (steps 1–3 already on `main`).

## Apply order after merge
1. Merge this PR
2. Run **`wbat-terraform-tfc`** — applies workspace version change
3. `wbat-terraform-aws` / `wbat-terraform-github` pick up 1.15.x on their next run

## Test plan
- [ ] `wbat-terraform-tfc` plan shows `terraform_version` update only (no resource replacement)
- [ ] After apply, HCP UI shows a 1.15.x version for all three workspaces
- [ ] Speculative plan on `wbat-terraform-aws` succeeds