### PR TITLE
fix(github): declare tellerstech_email from TFC variable set

### DIFF
--- a/github/credentials.tf
+++ b/github/credentials.tf
@@ -28,3 +28,8 @@ variable "personal_email" {
   description = "Personal email address for billing and admin notifications (brianateller@gmail.com)"
   default     = "email@address.com"
 }
+
+variable "tellerstech_email" {
+  description = "TellersTech email address for business notifications (tellerstech@gmail.com)"
+  default     = "email@address.com"
+}


### PR DESCRIPTION
## Summary
Declare `tellerstech_email` in `github/credentials.tf` to match the **Email Addresses** TFC variable set attached to all workspaces (`tfc/tfc-variable-set-email_address.tf`).

The value is injected via `terraform.tfvars` in HCP but was not declared in the github root module, producing:

> Warning: Value for undeclared variable `tellerstech_email`

## Test plan
- [ ] `terraform validate` in `github/` passes
- [ ] After merge + `wbat-terraform-github` apply, next plan/run has no `tellerstech_email` warning


Made with [Cursor](https://cursor.com)