### PR TITLE
feat(github): delete head branches automatically after PR merge

### DIFF
--- a/github/repos/iTerm2-Git-Status-Bar.tf
+++ b/github/repos/iTerm2-Git-Status-Bar.tf
@@ -9,6 +9,8 @@ resource "github_repository" "iTerm2-Git-Status-Bar" {
   has_projects         = true
   vulnerability_alerts = true
 
+  delete_branch_on_merge = true
+
   topics = [
     "bash",
     "iterm",

--- a/github/repos/wbat-terraform.tf
+++ b/github/repos/wbat-terraform.tf
@@ -9,6 +9,8 @@ resource "github_repository" "wbat-terraform" {
   has_projects         = true
   vulnerability_alerts = true
 
+  delete_branch_on_merge = true
+
   topics = [
     "aws",
     "hcl",


### PR DESCRIPTION
## Summary
Set `delete_branch_on_merge = true` on both Terraform-managed repos:
- `wbat-terraform`
- `iTerm2-Git-Status-Bar`

GitHub will automatically delete the head branch when a pull request is merged.

## Note
Only repos defined in `github/repos/` are managed here. Other org repos would need to be added to Terraform or configured manually in GitHub settings.

## Test plan
- [ ] `wbat-terraform-github` plan shows `delete_branch_on_merge = true` on both repositories (no other changes)
- [ ] After apply, GitHub repo Settings → General shows **Automatically delete head branches** enabled
- [ ] Merge a test PR and confirm the branch is removed


Made with [Cursor](https://cursor.com)