### PR TITLE
feat(github): manage TellersTechOrg/tellerstech-website

### DIFF
--- a/github/main.tf
+++ b/github/main.tf
@@ -19,6 +19,12 @@ provider "github" {
   owner = "wbat"
 }
 
+provider "github" {
+  alias = "tellerstechorg"
+  token = var.github_oauth_token
+  owner = "TellersTechOrg"
+}
+
 ######################################################
 # Modules
 ######################################################
@@ -26,4 +32,8 @@ module "repos" {
   source = "./repos"
 
   personal_email = var.personal_email
+
+  providers = {
+    github.tellerstechorg = github.tellerstechorg
+  }
 }

--- a/github/repos/tellerstech-website.tf
+++ b/github/repos/tellerstech-website.tf
@@ -21,17 +21,17 @@ resource "github_repository" "tellerstech-website" {
   description = "The WordPress Files for TellersTech.com (and ShipItWeekly.fm, OnCallBrief.com, and CodeDuck.ai)"
   visibility  = "private"
 
-  has_issues           = true
-  has_wiki             = false
-  has_projects         = true
-  has_downloads        = true
-  vulnerability_alerts = true
+  has_issues    = true
+  has_wiki      = false
+  has_projects  = true
+  has_downloads = true
 
   delete_branch_on_merge = true
 
-  allow_merge_commit = true
-  allow_squash_merge = true
-  allow_rebase_merge = true
+  allow_merge_commit  = true
+  allow_squash_merge  = true
+  allow_rebase_merge  = true
+  allow_auto_merge    = false
   allow_update_branch = true
 }
 

--- a/github/repos/tellerstech-website.tf
+++ b/github/repos/tellerstech-website.tf
@@ -32,6 +32,7 @@ resource "github_repository" "tellerstech-website" {
   allow_merge_commit = true
   allow_squash_merge = true
   allow_rebase_merge = true
+  allow_update_branch = true
 }
 
 resource "github_branch_default" "tellerstech-website-main" {

--- a/github/repos/tellerstech-website.tf
+++ b/github/repos/tellerstech-website.tf
@@ -1,0 +1,41 @@
+# TellersTechOrg/tellerstech-website — WordPress site files (imported; pre-existing repo).
+# Branch protection is not managed here: private repos on the current GitHub plan
+# return 403 from the branch protection API (requires GitHub Pro or public repo).
+
+import {
+  to       = github_repository.tellerstech-website
+  id       = "tellerstech-website"
+  provider = github.tellerstechorg
+}
+
+import {
+  to       = github_branch_default.tellerstech-website-main
+  id       = "tellerstech-website:main"
+  provider = github.tellerstechorg
+}
+
+resource "github_repository" "tellerstech-website" {
+  provider = github.tellerstechorg
+
+  name        = "tellerstech-website"
+  description = "The WordPress Files for TellersTech.com (and ShipItWeekly.fm, OnCallBrief.com, and CodeDuck.ai)"
+  visibility  = "private"
+
+  has_issues           = true
+  has_wiki             = false
+  has_projects         = true
+  has_downloads        = true
+  vulnerability_alerts = true
+
+  delete_branch_on_merge = true
+
+  allow_merge_commit = true
+  allow_squash_merge = true
+  allow_rebase_merge = true
+}
+
+resource "github_branch_default" "tellerstech-website-main" {
+  provider   = github.tellerstechorg
+  repository = github_repository.tellerstech-website.name
+  branch     = "main"
+}

--- a/github/repos/versions.tf
+++ b/github/repos/versions.tf
@@ -1,8 +1,9 @@
 terraform {
   required_providers {
     github = {
-      source  = "integrations/github"
-      version = "~>6.0"
+      source                = "integrations/github"
+      version               = "~>6.0"
+      configuration_aliases = [github.tellerstechorg]
     }
   }
   required_version = ">= 1.15.0"


### PR DESCRIPTION
## Summary
Bring [TellersTechOrg/tellerstech-website](https://github.com/TellersTechOrg/tellerstech-website) under the `wbat-terraform-github` workspace.

- Second GitHub provider alias: `github.tellerstechorg` (`owner = TellersTechOrg`)
- Import existing repo + `main` default branch (no recreate)
- Match live settings: private, issues/projects, `delete_branch_on_merge`, merge options

## Not in scope (yet)
- **Branch protection** — GitHub API returns 403 for this private repo on the current plan (*"Upgrade to GitHub Pro or make this repository public"*). Can add `github_branch_protection` later if the org upgrades or the repo goes public.
- **Repo contents** — only GitHub repository settings are managed, not WordPress files.

## Prerequisites
The `github_oauth_token` in HCP must have **admin** access to **TellersTechOrg** (same token already works via `gh` in testing).

## After merge
1. Apply **`wbat-terraform-github`**
2. Plan should **import** two resources (import blocks); expect minimal or no attribute changes
3. Remove the `import` blocks in a follow-up PR once apply succeeds (one-time bootstrap)

## Test plan
- [ ] `terraform validate` in `github/` passes
- [ ] `wbat-terraform-github` plan: import `tellerstech-website` + default branch, no replacement
- [ ] Post-apply: repo settings unchanged in GitHub UI


Made with [Cursor](https://cursor.com)