### PR TITLE
fix(github): fix tellerstech-website import (plan was creating)

### DIFF
--- a/github/imports.tf
+++ b/github/imports.tf
@@ -1,0 +1,15 @@
+# One-time imports for pre-existing TellersTechOrg resources.
+# Remove this file after a successful wbat-terraform-github apply.
+#
+# Import blocks must live in the root module (not repos/) and must not set
+# provider — the target resource's provider mapping is used automatically.
+
+import {
+  to = module.repos.github_repository.tellerstech-website
+  id = "tellerstech-website"
+}
+
+import {
+  to = module.repos.github_branch_default.tellerstech-website-main
+  id = "tellerstech-website:main"
+}

--- a/github/imports.tf
+++ b/github/imports.tf
@@ -9,7 +9,8 @@ import {
   id = "tellerstech-website"
 }
 
+# github_branch_default import id is repository name only (not repo:branch).
 import {
   to = module.repos.github_branch_default.tellerstech-website-main
-  id = "tellerstech-website:main"
+  id = "tellerstech-website"
 }

--- a/github/main.tf
+++ b/github/main.tf
@@ -34,6 +34,7 @@ module "repos" {
   personal_email = var.personal_email
 
   providers = {
+    github                = github
     github.tellerstechorg = github.tellerstechorg
   }
 }

--- a/github/repos/tellerstech-website.tf
+++ b/github/repos/tellerstech-website.tf
@@ -1,18 +1,7 @@
 # TellersTechOrg/tellerstech-website — WordPress site files (imported; pre-existing repo).
 # Branch protection is not managed here: private repos on the current GitHub plan
 # return 403 from the branch protection API (requires GitHub Pro or public repo).
-
-import {
-  to       = github_repository.tellerstech-website
-  id       = "tellerstech-website"
-  provider = github.tellerstechorg
-}
-
-import {
-  to       = github_branch_default.tellerstech-website-main
-  id       = "tellerstech-website:main"
-  provider = github.tellerstechorg
-}
+# Import blocks live in ../imports.tf (root module).
 
 resource "github_repository" "tellerstech-website" {
   provider = github.tellerstechorg


### PR DESCRIPTION
## Problem
`wbat-terraform-github` plan wants to **create** `tellerstech-website` instead of importing it.

Root cause: `import` blocks were inside the `repos/` child module **with `provider = github.tellerstechorg`**. That pattern is invalid for module imports — Terraform ignores it and falls through to create.

## Fix
- Add `github/imports.tf` at the **root** with:
  - `to = module.repos.github_repository.tellerstech-website`
  - `to = module.repos.github_branch_default.tellerstech-website-main`
  - **No `provider` argument** (inherited from resource config)
- Remove import blocks from `repos/tellerstech-website.tf`
- Pass `github = github` explicitly in `module.repos` providers map

## After merge
1. **Apply** `wbat-terraform-github` — plan should show **import** (2 resources), then apply
2. Follow-up PR to delete `github/imports.tf` once state is clean

## Test plan
- [ ] HCP plan shows `import` for 2 resources, not `create`
- [ ] Apply succeeds; repo unchanged in GitHub UI
- [ ] Second plan: no changes (then remove imports.tf)


Made with [Cursor](https://cursor.com)