### PR TITLE
refactor(github): reusable repository module + import 7 more repos

### DIFF
--- a/aws/imports.tf
+++ b/aws/imports.tf
@@ -35,19 +35,20 @@
 #   id = "eipassoc-0830bef1c1753210c"
 # }
 
-import {
-  to = module.us-east-1.module.ec2.aws_instance.secondary
-  id = "i-07e68eaf6cad1b838"
-}
+# Secondary EC2 instance - imported; commented out after successful apply.
+# import {
+#   to = module.us-east-1.module.ec2.aws_instance.secondary
+#   id = "i-07e68eaf6cad1b838"
+# }
 
-# SNS Topic for SES Email Forwarding
-import {
-  to = module.global.module.ses.aws_sns_topic.email_forwarding
-  id = "arn:aws:sns:us-east-1:708113892725:tellertech-email-forwarding"
-}
+# SNS Topic for SES Email Forwarding - imported; commented out after successful apply.
+# import {
+#   to = module.global.module.ses.aws_sns_topic.email_forwarding
+#   id = "arn:aws:sns:us-east-1:708113892725:tellertech-email-forwarding"
+# }
 
-# SNS Topic Policy (if exists - remove if import fails)
-import {
-  to = module.global.module.ses.aws_sns_topic_policy.email_forwarding
-  id = "arn:aws:sns:us-east-1:708113892725:tellertech-email-forwarding"
-}
+# SNS Topic Policy - imported; commented out after successful apply.
+# import {
+#   to = module.global.module.ses.aws_sns_topic_policy.email_forwarding
+#   id = "arn:aws:sns:us-east-1:708113892725:tellertech-email-forwarding"
+# }

--- a/github/imports.tf
+++ b/github/imports.tf
@@ -1,16 +1,75 @@
-# One-time imports for pre-existing TellersTechOrg resources.
-# Remove this file after a successful wbat-terraform-github apply.
+# One-time imports for pre-existing GitHub repositories.
+# After a successful wbat-terraform-github apply, comment out or remove the
+# corresponding blocks (per repository convention).
 #
 # Import blocks must live in the root module (not repos/) and must not set
 # provider — the target resource's provider mapping is used automatically.
+# github_repository import id is the repository name; github_branch_default
+# import id is also the repository name (not repo:branch).
+
+# --- wbat organization ---
 
 import {
-  to = module.repos.github_repository.tellerstech-website
-  id = "tellerstech-website"
+  to = module.repos.module.iterm_status.github_repository.this
+  id = "iterm-status"
+}
+import {
+  to = module.repos.module.iterm_status.github_branch_default.this
+  id = "iterm-status"
 }
 
-# github_branch_default import id is repository name only (not repo:branch).
 import {
-  to = module.repos.github_branch_default.tellerstech-website-main
-  id = "tellerstech-website"
+  to = module.repos.module.java_jar_test.github_repository.this
+  id = "java-jar-test"
+}
+import {
+  to = module.repos.module.java_jar_test.github_branch_default.this
+  id = "java-jar-test"
+}
+
+import {
+  to = module.repos.module.stocks_to_rss.github_repository.this
+  id = "stocks-to-rss"
+}
+import {
+  to = module.repos.module.stocks_to_rss.github_branch_default.this
+  id = "stocks-to-rss"
+}
+
+import {
+  to = module.repos.module.osticket_rest_api.github_repository.this
+  id = "osticket-rest-api"
+}
+import {
+  to = module.repos.module.osticket_rest_api.github_branch_default.this
+  id = "osticket-rest-api"
+}
+
+import {
+  to = module.repos.module.stripe_terminal.github_repository.this
+  id = "stripe-terminal"
+}
+import {
+  to = module.repos.module.stripe_terminal.github_branch_default.this
+  id = "stripe-terminal"
+}
+
+import {
+  to = module.repos.module.rss_2_0_generation_class.github_repository.this
+  id = "rss-2.0-generation-class"
+}
+import {
+  to = module.repos.module.rss_2_0_generation_class.github_branch_default.this
+  id = "rss-2.0-generation-class"
+}
+
+# --- TellersTechOrg organization ---
+
+import {
+  to = module.repos.module.terraform_module_example.github_repository.this
+  id = "terraform_module_example"
+}
+import {
+  to = module.repos.module.terraform_module_example.github_branch_default.this
+  id = "terraform_module_example"
 }

--- a/github/repos/iTerm2-Git-Status-Bar.tf
+++ b/github/repos/iTerm2-Git-Status-Bar.tf
@@ -1,15 +1,8 @@
-resource "github_repository" "iTerm2-Git-Status-Bar" {
+module "iterm2_git_status_bar" {
+  source = "./modules/repository"
+
   name        = "iTerm2-Git-Status-Bar"
   description = "This repository contains a custom script that provides a more reliable and full-featured Git status bar component for iTerm2"
-  visibility  = "public"
-
-  has_issues           = true
-  has_wiki             = true
-  has_downloads        = true
-  has_projects         = true
-  vulnerability_alerts = true
-
-  delete_branch_on_merge = true
 
   topics = [
     "bash",
@@ -21,32 +14,6 @@ resource "github_repository" "iTerm2-Git-Status-Bar" {
     "statusbar",
   ]
 
-}
-
-# Manage branch protection
-resource "github_branch_protection" "iTerm2-Git-Status-Bar-main" {
-  repository_id  = github_repository.iTerm2-Git-Status-Bar.node_id
-  pattern        = "main"
-  enforce_admins = false
-
-  require_conversation_resolution = true
-
-  required_pull_request_reviews {
-    dismiss_stale_reviews           = true
-    required_approving_review_count = 0
-  }
-
-  required_status_checks {
-    contexts = [
-      # Github Actions
-      "sh-checker"
-    ]
-    strict = true
-  }
-}
-
-# Default Branch
-resource "github_branch_default" "iTerm2-Git-Status-Bar-main" {
-  repository = github_repository.iTerm2-Git-Status-Bar.name
-  branch     = "main"
+  manage_branch_protection       = true
+  required_status_check_contexts = ["sh-checker"]
 }

--- a/github/repos/iterm-status.tf
+++ b/github/repos/iterm-status.tf
@@ -1,0 +1,6 @@
+module "iterm_status" {
+  source = "./modules/repository"
+
+  name        = "iterm-status"
+  description = "iTerm Dynamic Status Bar App"
+}

--- a/github/repos/java-jar-test.tf
+++ b/github/repos/java-jar-test.tf
@@ -1,0 +1,5 @@
+module "java_jar_test" {
+  source = "./modules/repository"
+
+  name = "java-jar-test"
+}

--- a/github/repos/modules/repository/main.tf
+++ b/github/repos/modules/repository/main.tf
@@ -13,6 +13,7 @@ resource "github_repository" "this" {
   vulnerability_alerts = var.vulnerability_alerts
 
   delete_branch_on_merge = var.delete_branch_on_merge
+  allow_update_branch    = var.allow_update_branch
 }
 
 resource "github_branch_default" "this" {

--- a/github/repos/modules/repository/main.tf
+++ b/github/repos/modules/repository/main.tf
@@ -1,0 +1,44 @@
+resource "github_repository" "this" {
+  name         = var.name
+  description  = var.description
+  homepage_url = var.homepage_url
+  visibility   = var.visibility
+  topics       = var.topics
+
+  has_issues    = var.has_issues
+  has_wiki      = var.has_wiki
+  has_projects  = var.has_projects
+  has_downloads = var.has_downloads
+
+  vulnerability_alerts = var.vulnerability_alerts
+
+  delete_branch_on_merge = var.delete_branch_on_merge
+}
+
+resource "github_branch_default" "this" {
+  repository = github_repository.this.name
+  branch     = var.default_branch
+}
+
+resource "github_branch_protection" "this" {
+  count = var.manage_branch_protection ? 1 : 0
+
+  repository_id  = github_repository.this.node_id
+  pattern        = var.branch_protection_pattern
+  enforce_admins = var.enforce_admins
+
+  require_conversation_resolution = var.require_conversation_resolution
+
+  required_pull_request_reviews {
+    dismiss_stale_reviews           = var.dismiss_stale_reviews
+    required_approving_review_count = var.required_approving_review_count
+  }
+
+  dynamic "required_status_checks" {
+    for_each = length(var.required_status_check_contexts) > 0 ? [1] : []
+    content {
+      contexts = var.required_status_check_contexts
+      strict   = true
+    }
+  }
+}

--- a/github/repos/modules/repository/outputs.tf
+++ b/github/repos/modules/repository/outputs.tf
@@ -1,0 +1,9 @@
+output "name" {
+  description = "Repository name."
+  value       = github_repository.this.name
+}
+
+output "node_id" {
+  description = "GraphQL node ID of the repository."
+  value       = github_repository.this.node_id
+}

--- a/github/repos/modules/repository/variables.tf
+++ b/github/repos/modules/repository/variables.tf
@@ -1,0 +1,112 @@
+variable "name" {
+  description = "Repository name."
+  type        = string
+}
+
+variable "description" {
+  description = "Repository description."
+  type        = string
+  default     = null
+}
+
+variable "homepage_url" {
+  description = "Repository homepage URL."
+  type        = string
+  default     = null
+}
+
+variable "visibility" {
+  description = "Repository visibility: public, private, or internal."
+  type        = string
+  default     = "public"
+}
+
+variable "topics" {
+  description = "Repository topics."
+  type        = list(string)
+  default     = []
+}
+
+variable "has_issues" {
+  description = "Enable GitHub Issues."
+  type        = bool
+  default     = true
+}
+
+variable "has_wiki" {
+  description = "Enable the repository wiki."
+  type        = bool
+  default     = true
+}
+
+variable "has_projects" {
+  description = "Enable repository projects."
+  type        = bool
+  default     = true
+}
+
+variable "has_downloads" {
+  description = "Enable repository downloads."
+  type        = bool
+  default     = true
+}
+
+variable "vulnerability_alerts" {
+  description = "Enable Dependabot vulnerability alerts. Not supported on private repos without GitHub Advanced Security."
+  type        = bool
+  default     = true
+}
+
+variable "delete_branch_on_merge" {
+  description = "Automatically delete head branches after PRs are merged."
+  type        = bool
+  default     = true
+}
+
+variable "default_branch" {
+  description = "Default branch name."
+  type        = string
+  default     = "main"
+}
+
+variable "manage_branch_protection" {
+  description = "Whether to manage a branch protection rule for this repository."
+  type        = bool
+  default     = false
+}
+
+variable "branch_protection_pattern" {
+  description = "Branch pattern the protection rule applies to."
+  type        = string
+  default     = "main"
+}
+
+variable "enforce_admins" {
+  description = "Enforce branch protection rules on administrators."
+  type        = bool
+  default     = false
+}
+
+variable "require_conversation_resolution" {
+  description = "Require conversation resolution before merging."
+  type        = bool
+  default     = true
+}
+
+variable "dismiss_stale_reviews" {
+  description = "Dismiss stale pull request approvals when new commits are pushed."
+  type        = bool
+  default     = true
+}
+
+variable "required_approving_review_count" {
+  description = "Number of approving reviews required to merge."
+  type        = number
+  default     = 0
+}
+
+variable "required_status_check_contexts" {
+  description = "Status checks that must pass before merging. Empty disables the required_status_checks block."
+  type        = list(string)
+  default     = []
+}

--- a/github/repos/modules/repository/variables.tf
+++ b/github/repos/modules/repository/variables.tf
@@ -63,6 +63,12 @@ variable "delete_branch_on_merge" {
   default     = true
 }
 
+variable "allow_update_branch" {
+  description = "Always suggest updating pull request branches."
+  type        = bool
+  default     = false
+}
+
 variable "default_branch" {
   description = "Default branch name."
   type        = string

--- a/github/repos/modules/repository/versions.tf
+++ b/github/repos/modules/repository/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~>6.0"
+    }
+  }
+  required_version = ">= 1.15.0"
+}

--- a/github/repos/moved.tf
+++ b/github/repos/moved.tf
@@ -1,0 +1,33 @@
+# State moves for repositories refactored into the ./modules/repository module.
+# These keep the existing resources in place (no destroy/recreate) as their
+# addresses change from top-level resources to module resources.
+
+moved {
+  from = github_repository.wbat-terraform
+  to   = module.wbat_terraform.github_repository.this
+}
+
+moved {
+  from = github_branch_default.wbat-terraform-main
+  to   = module.wbat_terraform.github_branch_default.this
+}
+
+moved {
+  from = github_branch_protection.wbat-terraform-main
+  to   = module.wbat_terraform.github_branch_protection.this[0]
+}
+
+moved {
+  from = github_repository.iTerm2-Git-Status-Bar
+  to   = module.iterm2_git_status_bar.github_repository.this
+}
+
+moved {
+  from = github_branch_default.iTerm2-Git-Status-Bar-main
+  to   = module.iterm2_git_status_bar.github_branch_default.this
+}
+
+moved {
+  from = github_branch_protection.iTerm2-Git-Status-Bar-main
+  to   = module.iterm2_git_status_bar.github_branch_protection.this[0]
+}

--- a/github/repos/osticket-rest-api.tf
+++ b/github/repos/osticket-rest-api.tf
@@ -1,0 +1,7 @@
+module "osticket_rest_api" {
+  source = "./modules/repository"
+
+  name           = "osticket-rest-api"
+  description    = "osTicket REST API"
+  default_branch = "master"
+}

--- a/github/repos/rss-2.0-generation-class.tf
+++ b/github/repos/rss-2.0-generation-class.tf
@@ -1,0 +1,7 @@
+module "rss_2_0_generation_class" {
+  source = "./modules/repository"
+
+  name           = "rss-2.0-generation-class"
+  description    = "RSS 2.0 Generation Class"
+  default_branch = "master"
+}

--- a/github/repos/stocks-to-rss.tf
+++ b/github/repos/stocks-to-rss.tf
@@ -1,0 +1,7 @@
+module "stocks_to_rss" {
+  source = "./modules/repository"
+
+  name           = "stocks-to-rss"
+  description    = "Stock Prices to RSS"
+  default_branch = "master"
+}

--- a/github/repos/stripe-terminal.tf
+++ b/github/repos/stripe-terminal.tf
@@ -1,0 +1,7 @@
+module "stripe_terminal" {
+  source = "./modules/repository"
+
+  name           = "stripe-terminal"
+  description    = "Stripe Terminal"
+  default_branch = "master"
+}

--- a/github/repos/terraform_module_example.tf
+++ b/github/repos/terraform_module_example.tf
@@ -9,4 +9,7 @@ module "terraform_module_example" {
   name        = "terraform_module_example"
   description = "An Example of a Terraform Module"
   has_wiki    = false
+
+  # Preserve the repo's existing "suggest updating PR branches" setting.
+  allow_update_branch = true
 }

--- a/github/repos/terraform_module_example.tf
+++ b/github/repos/terraform_module_example.tf
@@ -1,0 +1,12 @@
+# TellersTechOrg/terraform_module_example — uses the TellersTechOrg provider alias.
+module "terraform_module_example" {
+  source = "./modules/repository"
+
+  providers = {
+    github = github.tellerstechorg
+  }
+
+  name        = "terraform_module_example"
+  description = "An Example of a Terraform Module"
+  has_wiki    = false
+}

--- a/github/repos/wbat-terraform.tf
+++ b/github/repos/wbat-terraform.tf
@@ -1,15 +1,8 @@
-resource "github_repository" "wbat-terraform" {
+module "wbat_terraform" {
+  source = "./modules/repository"
+
   name        = "wbat-terraform"
   description = "WBAT Terraform Repo"
-  visibility  = "public"
-
-  has_issues           = true
-  has_wiki             = true
-  has_downloads        = true
-  has_projects         = true
-  vulnerability_alerts = true
-
-  delete_branch_on_merge = true
 
   topics = [
     "aws",
@@ -19,40 +12,18 @@ resource "github_repository" "wbat-terraform" {
     "terraform-cloud",
     "terraform-github",
   ]
-}
 
-# Manage branch protection
-resource "github_branch_protection" "wbat-terraform-main" {
-  repository_id  = github_repository.wbat-terraform.node_id
-  pattern        = "main"
-  enforce_admins = false
+  manage_branch_protection = true
+  required_status_check_contexts = [
+    # TFC
+    "Terraform Cloud/WBAT/wbat-terraform-aws",
+    "Terraform Cloud/WBAT/wbat-terraform-github",
+    "Terraform Cloud/WBAT/wbat-terraform-tfc",
 
-  require_conversation_resolution = true
-
-  required_pull_request_reviews {
-    dismiss_stale_reviews           = true
-    required_approving_review_count = 0
-  }
-
-  required_status_checks {
-    contexts = [
-      # TFC
-      "Terraform Cloud/WBAT/wbat-terraform-aws",
-      "Terraform Cloud/WBAT/wbat-terraform-github",
-      "Terraform Cloud/WBAT/wbat-terraform-tfc",
-
-      # Github Actions (version-independent names; see aws/docs/terraform-version-upgrade.md)
-      "Format",
-      "Validate (aws)",
-      "Validate (github)",
-      "Validate (tfc)",
-    ]
-    strict = true
-  }
-}
-
-# Default Branch
-resource "github_branch_default" "wbat-terraform-main" {
-  repository = github_repository.wbat-terraform.name
-  branch     = "main"
+    # Github Actions (version-independent names; see aws/docs/terraform-version-upgrade.md)
+    "Format",
+    "Validate (aws)",
+    "Validate (github)",
+    "Validate (tfc)",
+  ]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Repo-management improvements across three logical commits:

1. **chore(aws)**: comment out the already-applied `secondary` EC2 instance and SES SNS topic/policy import blocks, matching the EC2/EIP cleanup convention.
2. **refactor(github)**: add a reusable `github/repos/modules/repository` module (repository + default branch + optional branch protection) and migrate the two existing wbat repos onto it using `moved` blocks (no destroy/recreate).
3. **feat(github)**: import 7 previously-unmanaged repositories via the new module.

## Newly managed repositories

**wbat org** (default provider):
- `iterm-status`, `java-jar-test`, `stocks-to-rss`, `osticket-rest-api`, `stripe-terminal`, `rss-2.0-generation-class`

**TellersTechOrg** (aliased provider):
- `terraform_module_example`

Current settings were read from the GitHub API so config matches reality — notably `stocks-to-rss`, `osticket-rest-api`, `stripe-terminal`, and `rss-2.0-generation-class` use `master` as the default branch, and `terraform_module_example` has the wiki disabled. Forks (14 in wbat) were intentionally skipped — they expose limited settings and are low value to manage; happy to add them if wanted.

## Expected apply behavior

- **Migrated repos** (`wbat-terraform`, `iTerm2-Git-Status-Bar`): `moved` blocks transfer state addresses; no destroy/recreate, config is byte-equivalent so no attribute changes expected.
- **Imported repos**: brought into state via `import` blocks. Some in-place standardization may apply (e.g. enabling `vulnerability_alerts` / `delete_branch_on_merge`) since the module defaults to those. No destroys, no visibility changes (all are public).

## Notes

- `tellerstech-website` is intentionally left as a standalone resource (private repo on a plan where the branch-protection API 403s; special-cased with the aliased provider). It can be migrated to the module in a follow-up.
- Branch protection is **not** enabled for the 7 imported repos (no CI checks to require yet); the module supports it via `manage_branch_protection` when desired.

## Validation

- `terraform fmt -recursive -check` clean.
- `terraform validate` passes (Terraform 1.15.7).
- Please confirm the TFC github plan shows **0 to destroy** before merge.
- TFC applies on merge.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-18f66bde-35d1-482f-a2a6-eb1df126a167"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-18f66bde-35d1-482f-a2a6-eb1df126a167"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

