### PR TITLE
feat(ses): hardened inbound email forward to Gmail/Roundcube

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ venv
 scripts/__pycache__/
 *.pyc
 scripts/shrink-migration.config.yaml
+
+# Generated Lambda zip artifacts
+aws/global/ses/lambda/*.zip

--- a/aws/credentials.tf
+++ b/aws/credentials.tf
@@ -13,15 +13,47 @@
 ######################################################
 # Email Addresses
 #
+# Prefer Terraform Cloud sensitive variables / variable sets for real values.
+# credentials.auto.tfvars is gitignored — never commit real addresses.
+# For SES inbound, also set:
+#   enable_inbound_forwarding = true
+#   inbound_recipients        = ["recipient@example.com"]  # sensitive HCL
+#   inbound_alert_email       = "alerts@example.com"       # optional, sensitive
+# And populate Secrets Manager tellerstech/ses-inbound/runtime-config after apply.
+#
 ######################################################
 variable "personal_email" {
-  description = "Personal email address for billing and admin notifications (brianateller@gmail.com)"
-  default     = "email@address.com"
+  description = "Personal email for billing/admin notifications (TFC sensitive preferred)"
+  type        = string
+  sensitive   = true
+  default     = ""
 }
 
 variable "tellerstech_email" {
-  description = "TellersTech email address for business notifications (tellerstech@gmail.com)"
-  default     = "email@address.com"
+  description = "Business notification email for legacy SES SNS topics (TFC sensitive preferred)"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "enable_inbound_forwarding" {
+  description = "Provision SES inbound receive + gated Lambda forward to Gmail/Roundcube"
+  type        = bool
+  default     = false
+}
+
+variable "inbound_recipients" {
+  description = "Allowlisted addresses for SES receipt rules (TFC sensitive HCL list)"
+  type        = list(string)
+  sensitive   = true
+  default     = []
+}
+
+variable "inbound_alert_email" {
+  description = "Optional SNS email for inbound flood/error alarms (TFC sensitive)"
+  type        = string
+  sensitive   = true
+  default     = ""
 }
 
 ######################################################

--- a/aws/global/main.tf
+++ b/aws/global/main.tf
@@ -37,9 +37,9 @@ module "cloudwatch" {
 module "ses" {
   source = "./ses"
 
-  core_tags            = var.core_tags
-  tellerstech_email    = var.tellerstech_email
+  core_tags                 = var.core_tags
+  tellerstech_email         = var.tellerstech_email
   enable_inbound_forwarding = var.enable_inbound_forwarding
-  inbound_recipients   = var.inbound_recipients
-  inbound_alert_email  = var.inbound_alert_email
+  inbound_recipients        = var.inbound_recipients
+  inbound_alert_email       = var.inbound_alert_email
 }

--- a/aws/global/main.tf
+++ b/aws/global/main.tf
@@ -37,6 +37,9 @@ module "cloudwatch" {
 module "ses" {
   source = "./ses"
 
-  core_tags         = var.core_tags
-  tellerstech_email = var.tellerstech_email
+  core_tags            = var.core_tags
+  tellerstech_email    = var.tellerstech_email
+  enable_inbound_forwarding = var.enable_inbound_forwarding
+  inbound_recipients   = var.inbound_recipients
+  inbound_alert_email  = var.inbound_alert_email
 }

--- a/aws/global/outputs.tf
+++ b/aws/global/outputs.tf
@@ -50,3 +50,24 @@ output "directadmin_backup_iam_user" {
   value       = aws_iam_user.directadmin_backup.name
   description = "IAM user DirectAdmin uses for S3 backups; create an access key for it and paste into DA."
 }
+
+# SES inbound → Gmail / Roundcube
+output "ses_inbound_mx_records" {
+  value       = module.ses.ses_inbound_mx_records
+  description = "MX records for SES inbound cutover (set in DirectAdmin DNS)"
+}
+
+output "ses_inbound_cutover_checklist" {
+  value       = module.ses.inbound_cutover_checklist
+  description = "Post-apply steps for SES inbound (addresses live in TFC + Secrets Manager)"
+}
+
+output "ses_inbound_runtime_config_secret_name" {
+  value       = module.ses.inbound_runtime_config_secret_name
+  description = "Secrets Manager secret for inbound runtime config"
+}
+
+output "ses_inbound_alerts_topic_arn" {
+  value       = module.ses.inbound_alerts_topic_arn
+  description = "SNS topic for inbound flood/error alarms"
+}

--- a/aws/global/ses/inbound-forwarding.tf
+++ b/aws/global/ses/inbound-forwarding.tf
@@ -1,0 +1,745 @@
+# SES inbound receive → sync gate → S3 → SQS → worker → Gmail + Roundcube.
+#
+# Cutover (no mailbox addresses in this public repo):
+#   1. Set TFC sensitive var inbound_recipients (HCL list)
+#   2. Populate Secrets Manager runtime-config JSON (see secret name output)
+#   3. terraform apply
+#   4. Remove DirectAdmin Gmail forwarders for allowlisted addresses
+#   5. Point domain MX at SES inbound (see ses_inbound_mx_records output)
+#   6. Test from an external account; check Gmail, Roundcube, Lambda logs
+#
+# Roundcube copies use SMTP submission :587 (AUTH). Port 25 from Lambda is blocked.
+
+data "aws_region" "current" {}
+
+locals {
+  inbound_enabled   = var.enable_inbound_forwarding
+  inbound_prefix    = "inbound/"
+  quarantine_prefix = "quarantine/"
+  # Recipients come from TFC (sensitive). nonsensitive() is required for for_each;
+  # values still appear in private TFC state / SES console, never in git defaults.
+  recipients = local.inbound_enabled ? nonsensitive(var.inbound_recipients) : []
+  recipient_rule_names = {
+    for addr in local.recipients :
+    addr => "fwd-${substr(sha1(addr), 0, 10)}"
+  }
+  sorted_recipients = sort(local.recipients)
+}
+
+# -----------------------------------------------------------------------------
+# S3
+# -----------------------------------------------------------------------------
+
+resource "aws_s3_bucket" "ses_inbound" {
+  count  = local.inbound_enabled ? 1 : 0
+  bucket = "tellerstech-ses-inbound-${data.aws_caller_identity.current.account_id}"
+
+  tags = merge(
+    var.core_tags,
+    {
+      "Name"     = "TellersTech SES Inbound Mail"
+      "scm:file" = "aws/global/ses/inbound-forwarding.tf"
+    },
+  )
+}
+
+resource "aws_s3_bucket_public_access_block" "ses_inbound" {
+  count  = local.inbound_enabled ? 1 : 0
+  bucket = aws_s3_bucket.ses_inbound[0].id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "ses_inbound" {
+  count  = local.inbound_enabled ? 1 : 0
+  bucket = aws_s3_bucket.ses_inbound[0].id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "ses_inbound" {
+  count  = local.inbound_enabled ? 1 : 0
+  bucket = aws_s3_bucket.ses_inbound[0].id
+
+  rule {
+    id     = "expire-raw-mail"
+    status = "Enabled"
+
+    filter {}
+
+    expiration {
+      days = var.inbound_mail_retention_days
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "ses_inbound" {
+  count  = local.inbound_enabled ? 1 : 0
+  bucket = aws_s3_bucket.ses_inbound[0].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowSESPuts"
+        Effect = "Allow"
+        Principal = {
+          Service = "ses.amazonaws.com"
+        }
+        Action   = "s3:PutObject"
+        Resource = "${aws_s3_bucket.ses_inbound[0].arn}/*"
+        Condition = {
+          StringEquals = {
+            "AWS:SourceAccount" = data.aws_caller_identity.current.account_id
+          }
+        }
+      }
+    ]
+  })
+}
+
+# -----------------------------------------------------------------------------
+# Secrets Manager — runtime config (addresses + SMTP). Seed is empty; fill in AWS.
+# -----------------------------------------------------------------------------
+
+resource "aws_secretsmanager_secret" "runtime_config" {
+  count       = local.inbound_enabled ? 1 : 0
+  name        = "tellerstech/ses-inbound/runtime-config"
+  description = "SES inbound runtime config: recipients, gmail_destination, alert_email, smtp"
+
+  tags = merge(
+    var.core_tags,
+    {
+      "Name"     = "TellersTech SES Inbound Runtime Config"
+      "scm:file" = "aws/global/ses/inbound-forwarding.tf"
+    },
+  )
+}
+
+resource "aws_secretsmanager_secret_version" "runtime_config" {
+  count     = local.inbound_enabled ? 1 : 0
+  secret_id = aws_secretsmanager_secret.runtime_config[0].id
+
+  secret_string = jsonencode({
+    gmail_destination = ""
+    alert_email       = ""
+    recipients        = []
+    smtp = {
+      host      = ""
+      port      = 587
+      mailboxes = {}
+    }
+  })
+
+  lifecycle {
+    ignore_changes = [secret_string]
+  }
+}
+
+# -----------------------------------------------------------------------------
+# DynamoDB — rate limits + idempotency
+# -----------------------------------------------------------------------------
+
+resource "aws_dynamodb_table" "inbound_limits" {
+  count        = local.inbound_enabled ? 1 : 0
+  name         = "tellerstech-ses-inbound-limits"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "pk"
+  range_key    = "sk"
+
+  attribute {
+    name = "pk"
+    type = "S"
+  }
+
+  attribute {
+    name = "sk"
+    type = "S"
+  }
+
+  ttl {
+    attribute_name = "ttl"
+    enabled        = true
+  }
+
+  tags = merge(
+    var.core_tags,
+    {
+      "Name"     = "TellersTech SES Inbound Limits"
+      "scm:file" = "aws/global/ses/inbound-forwarding.tf"
+    },
+  )
+}
+
+# -----------------------------------------------------------------------------
+# SQS + DLQ
+# -----------------------------------------------------------------------------
+
+resource "aws_sqs_queue" "inbound_dlq" {
+  count                     = local.inbound_enabled ? 1 : 0
+  name                      = "tellerstech-ses-inbound-dlq"
+  message_retention_seconds = 1209600
+
+  tags = merge(
+    var.core_tags,
+    {
+      "Name"     = "TellersTech SES Inbound DLQ"
+      "scm:file" = "aws/global/ses/inbound-forwarding.tf"
+    },
+  )
+}
+
+resource "aws_sqs_queue" "inbound" {
+  count                      = local.inbound_enabled ? 1 : 0
+  name                       = "tellerstech-ses-inbound"
+  visibility_timeout_seconds = 120
+  message_retention_seconds  = 345600
+  receive_wait_time_seconds  = 10
+
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.inbound_dlq[0].arn
+    maxReceiveCount     = 3
+  })
+
+  tags = merge(
+    var.core_tags,
+    {
+      "Name"     = "TellersTech SES Inbound Queue"
+      "scm:file" = "aws/global/ses/inbound-forwarding.tf"
+    },
+  )
+}
+
+resource "aws_sqs_queue_policy" "inbound" {
+  count     = local.inbound_enabled ? 1 : 0
+  queue_url = aws_sqs_queue.inbound[0].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowS3Send"
+        Effect = "Allow"
+        Principal = {
+          Service = "s3.amazonaws.com"
+        }
+        Action   = "sqs:SendMessage"
+        Resource = aws_sqs_queue.inbound[0].arn
+        Condition = {
+          ArnEquals = {
+            "aws:SourceArn" = aws_s3_bucket.ses_inbound[0].arn
+          }
+        }
+      }
+    ]
+  })
+}
+
+# -----------------------------------------------------------------------------
+# Gate Lambda (sync)
+# -----------------------------------------------------------------------------
+
+data "archive_file" "gate_mail" {
+  count       = local.inbound_enabled ? 1 : 0
+  type        = "zip"
+  source_file = "${path.module}/lambda/gate_mail.py"
+  output_path = "${path.module}/lambda/gate_mail.zip"
+}
+
+resource "aws_iam_role" "gate_mail" {
+  count = local.inbound_enabled ? 1 : 0
+  name  = "tellerstech-ses-inbound-gate"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+
+  tags = merge(
+    var.core_tags,
+    {
+      "Name"     = "TellersTech SES Inbound Gate"
+      "scm:file" = "aws/global/ses/inbound-forwarding.tf"
+    },
+  )
+}
+
+resource "aws_iam_role_policy" "gate_mail" {
+  count = local.inbound_enabled ? 1 : 0
+  name  = "tellerstech-ses-inbound-gate"
+  role  = aws_iam_role.gate_mail[0].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "Logs"
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+        Resource = "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
+      },
+      {
+        Sid      = "ReadRuntimeConfig"
+        Effect   = "Allow"
+        Action   = ["secretsmanager:GetSecretValue"]
+        Resource = aws_secretsmanager_secret.runtime_config[0].arn
+      }
+    ]
+  })
+}
+
+resource "aws_cloudwatch_log_group" "gate_mail" {
+  count             = local.inbound_enabled ? 1 : 0
+  name              = "/aws/lambda/tellerstech-ses-inbound-gate"
+  retention_in_days = 30
+
+  tags = merge(
+    var.core_tags,
+    { "scm:file" = "aws/global/ses/inbound-forwarding.tf" },
+  )
+}
+
+resource "aws_lambda_function" "gate_mail" {
+  count = local.inbound_enabled ? 1 : 0
+
+  function_name = "tellerstech-ses-inbound-gate"
+  role          = aws_iam_role.gate_mail[0].arn
+  handler       = "gate_mail.handler"
+  runtime       = "python3.12"
+  timeout       = 10
+  memory_size   = 128
+
+  filename         = data.archive_file.gate_mail[0].output_path
+  source_code_hash = data.archive_file.gate_mail[0].output_base64sha256
+
+  environment {
+    variables = {
+      RUNTIME_CONFIG_SECRET_ARN = aws_secretsmanager_secret.runtime_config[0].arn
+    }
+  }
+
+  depends_on = [aws_cloudwatch_log_group.gate_mail]
+
+  tags = merge(
+    var.core_tags,
+    {
+      "Name"     = "TellersTech SES Inbound Gate"
+      "scm:file" = "aws/global/ses/inbound-forwarding.tf"
+    },
+  )
+}
+
+resource "aws_lambda_permission" "gate_ses" {
+  count          = local.inbound_enabled ? 1 : 0
+  statement_id   = "AllowSESInvokeGate"
+  action         = "lambda:InvokeFunction"
+  function_name  = aws_lambda_function.gate_mail[0].function_name
+  principal      = "ses.amazonaws.com"
+  source_account = data.aws_caller_identity.current.account_id
+}
+
+# -----------------------------------------------------------------------------
+# Worker Lambda (async via SQS)
+# -----------------------------------------------------------------------------
+
+data "archive_file" "forward_mail" {
+  count       = local.inbound_enabled ? 1 : 0
+  type        = "zip"
+  source_file = "${path.module}/lambda/forward_mail.py"
+  output_path = "${path.module}/lambda/forward_mail.zip"
+}
+
+resource "aws_iam_role" "forward_mail" {
+  count = local.inbound_enabled ? 1 : 0
+  name  = "tellerstech-ses-inbound-forward"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+
+  tags = merge(
+    var.core_tags,
+    {
+      "Name"     = "TellersTech SES Inbound Forward"
+      "scm:file" = "aws/global/ses/inbound-forwarding.tf"
+    },
+  )
+}
+
+resource "aws_iam_role_policy" "forward_mail" {
+  count = local.inbound_enabled ? 1 : 0
+  name  = "tellerstech-ses-inbound-forward"
+  role  = aws_iam_role.forward_mail[0].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "Logs"
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+        Resource = "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
+      },
+      {
+        Sid    = "S3Mail"
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:HeadObject"
+        ]
+        Resource = "${aws_s3_bucket.ses_inbound[0].arn}/*"
+      },
+      {
+        Sid      = "SendAsDomain"
+        Effect   = "Allow"
+        Action   = ["ses:SendRawEmail", "ses:SendEmail"]
+        Resource = "*"
+      },
+      {
+        Sid      = "ReadRuntimeConfig"
+        Effect   = "Allow"
+        Action   = ["secretsmanager:GetSecretValue"]
+        Resource = aws_secretsmanager_secret.runtime_config[0].arn
+      },
+      {
+        Sid    = "DynamoLimits"
+        Effect = "Allow"
+        Action = [
+          "dynamodb:PutItem",
+          "dynamodb:UpdateItem",
+          "dynamodb:GetItem",
+          "dynamodb:DeleteItem"
+        ]
+        Resource = aws_dynamodb_table.inbound_limits[0].arn
+      },
+      {
+        Sid    = "SQSConsume"
+        Effect = "Allow"
+        Action = [
+          "sqs:ReceiveMessage",
+          "sqs:DeleteMessage",
+          "sqs:GetQueueAttributes",
+          "sqs:ChangeMessageVisibility"
+        ]
+        Resource = aws_sqs_queue.inbound[0].arn
+      },
+      {
+        Sid      = "Metrics"
+        Effect   = "Allow"
+        Action   = ["cloudwatch:PutMetricData"]
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "cloudwatch:namespace" = "TellersTech/SESInbound"
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_cloudwatch_log_group" "forward_mail" {
+  count             = local.inbound_enabled ? 1 : 0
+  name              = "/aws/lambda/tellerstech-ses-inbound-forward"
+  retention_in_days = 30
+
+  tags = merge(
+    var.core_tags,
+    { "scm:file" = "aws/global/ses/inbound-forwarding.tf" },
+  )
+}
+
+resource "aws_lambda_function" "forward_mail" {
+  count = local.inbound_enabled ? 1 : 0
+
+  function_name                  = "tellerstech-ses-inbound-forward"
+  role                           = aws_iam_role.forward_mail[0].arn
+  handler                        = "forward_mail.handler"
+  runtime                        = "python3.12"
+  timeout                        = 60
+  memory_size                    = 256
+  reserved_concurrent_executions = var.inbound_worker_reserved_concurrency
+
+  filename         = data.archive_file.forward_mail[0].output_path
+  source_code_hash = data.archive_file.forward_mail[0].output_base64sha256
+
+  environment {
+    variables = {
+      RUNTIME_CONFIG_SECRET_ARN = aws_secretsmanager_secret.runtime_config[0].arn
+      INBOUND_PREFIX            = local.inbound_prefix
+      QUARANTINE_PREFIX         = local.quarantine_prefix
+      LIMITS_TABLE_NAME         = aws_dynamodb_table.inbound_limits[0].name
+      INBOUND_BUCKET            = aws_s3_bucket.ses_inbound[0].id
+      MAX_MESSAGE_BYTES         = tostring(var.inbound_max_message_bytes)
+      RATE_LIMIT_PER_RECIPIENT  = tostring(var.inbound_rate_limit_per_recipient)
+      RATE_LIMIT_GLOBAL         = tostring(var.inbound_rate_limit_global)
+      METRIC_NAMESPACE          = "TellersTech/SESInbound"
+    }
+  }
+
+  depends_on = [aws_cloudwatch_log_group.forward_mail]
+
+  tags = merge(
+    var.core_tags,
+    {
+      "Name"     = "TellersTech SES Inbound Forward"
+      "scm:file" = "aws/global/ses/inbound-forwarding.tf"
+    },
+  )
+}
+
+resource "aws_lambda_event_source_mapping" "inbound_sqs" {
+  count            = local.inbound_enabled ? 1 : 0
+  event_source_arn = aws_sqs_queue.inbound[0].arn
+  function_name    = aws_lambda_function.forward_mail[0].arn
+  batch_size       = 1
+  enabled          = true
+}
+
+resource "aws_s3_bucket_notification" "ses_inbound" {
+  count  = local.inbound_enabled ? 1 : 0
+  bucket = aws_s3_bucket.ses_inbound[0].id
+
+  queue {
+    queue_arn     = aws_sqs_queue.inbound[0].arn
+    events        = ["s3:ObjectCreated:*"]
+    filter_prefix = local.inbound_prefix
+  }
+
+  depends_on = [aws_sqs_queue_policy.inbound]
+}
+
+# -----------------------------------------------------------------------------
+# SES receipt rules
+# -----------------------------------------------------------------------------
+
+resource "aws_ses_receipt_rule_set" "inbound" {
+  count         = local.inbound_enabled ? 1 : 0
+  rule_set_name = "tellerstech-inbound"
+}
+
+resource "aws_ses_active_receipt_rule_set" "inbound" {
+  count         = local.inbound_enabled ? 1 : 0
+  rule_set_name = aws_ses_receipt_rule_set.inbound[0].rule_set_name
+}
+
+resource "aws_ses_receipt_rule" "forward" {
+  for_each = local.inbound_enabled ? local.recipient_rule_names : {}
+
+  name          = each.value
+  rule_set_name = aws_ses_receipt_rule_set.inbound[0].rule_set_name
+  recipients    = [each.key]
+  enabled       = true
+  scan_enabled  = true
+  tls_policy    = var.inbound_tls_policy
+
+  # Chain rules in sorted address order so catch-all can follow the last one.
+  after = (
+    index(local.sorted_recipients, each.key) == 0
+    ? null
+    : local.recipient_rule_names[local.sorted_recipients[index(local.sorted_recipients, each.key) - 1]]
+  )
+
+  lambda_action {
+    function_arn    = aws_lambda_function.gate_mail[0].arn
+    invocation_type = "RequestResponse"
+    position        = 1
+  }
+
+  s3_action {
+    bucket_name       = aws_s3_bucket.ses_inbound[0].id
+    object_key_prefix = "${local.inbound_prefix}${each.key}/"
+    position          = 2
+  }
+
+  stop_action {
+    scope    = "RuleSet"
+    position = 3
+  }
+
+  depends_on = [
+    aws_s3_bucket_policy.ses_inbound,
+    aws_lambda_permission.gate_ses,
+  ]
+}
+
+resource "aws_ses_receipt_rule" "catch_all_bounce" {
+  count = local.inbound_enabled ? 1 : 0
+
+  name          = "catch-all-bounce"
+  rule_set_name = aws_ses_receipt_rule_set.inbound[0].rule_set_name
+  enabled       = true
+  scan_enabled  = true
+  tls_policy    = var.inbound_tls_policy
+
+  # No recipients list => matches remaining recipients on verified identities.
+  after = length(local.sorted_recipients) > 0 ? local.recipient_rule_names[local.sorted_recipients[length(local.sorted_recipients) - 1]] : null
+
+  bounce_action {
+    message         = "Mailbox not available"
+    sender          = "mailer-daemon@${var.ses_identity}"
+    smtp_reply_code = "550"
+    status_code     = "5.1.1"
+    position        = 1
+  }
+
+  stop_action {
+    scope    = "RuleSet"
+    position = 2
+  }
+
+  depends_on = [aws_ses_receipt_rule.forward]
+}
+
+# -----------------------------------------------------------------------------
+# Alarms
+# -----------------------------------------------------------------------------
+
+resource "aws_sns_topic" "inbound_alerts" {
+  count = local.inbound_enabled ? 1 : 0
+  name  = "tellerstech-ses-inbound-alerts"
+
+  tags = merge(
+    var.core_tags,
+    {
+      "Name"     = "TellersTech SES Inbound Alerts"
+      "scm:file" = "aws/global/ses/inbound-forwarding.tf"
+    },
+  )
+}
+
+resource "aws_sns_topic_subscription" "inbound_alerts_email" {
+  count     = local.inbound_enabled && var.inbound_alert_email != "" ? 1 : 0
+  topic_arn = aws_sns_topic.inbound_alerts[0].arn
+  protocol  = "email"
+  endpoint  = var.inbound_alert_email
+}
+
+resource "aws_cloudwatch_metric_alarm" "flood_suppressed" {
+  count               = local.inbound_enabled ? 1 : 0
+  alarm_name          = "tellerstech-ses-inbound-flood"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  metric_name         = "FloodSuppressed"
+  namespace           = "TellersTech/SESInbound"
+  period              = 300
+  statistic           = "Sum"
+  threshold           = 1
+  treat_missing_data  = "notBreaching"
+  alarm_description   = "SES inbound flood rate limit suppressed one or more messages"
+  alarm_actions       = [aws_sns_topic.inbound_alerts[0].arn]
+  ok_actions          = [aws_sns_topic.inbound_alerts[0].arn]
+
+  tags = merge(
+    var.core_tags,
+    { "scm:file" = "aws/global/ses/inbound-forwarding.tf" },
+  )
+}
+
+resource "aws_cloudwatch_metric_alarm" "inbound_dlq" {
+  count               = local.inbound_enabled ? 1 : 0
+  alarm_name          = "tellerstech-ses-inbound-dlq"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  metric_name         = "ApproximateNumberOfMessagesVisible"
+  namespace           = "AWS/SQS"
+  period              = 60
+  statistic           = "Maximum"
+  threshold           = 1
+  treat_missing_data  = "notBreaching"
+  alarm_description   = "SES inbound worker DLQ has messages"
+  alarm_actions       = [aws_sns_topic.inbound_alerts[0].arn]
+  ok_actions          = [aws_sns_topic.inbound_alerts[0].arn]
+
+  dimensions = {
+    QueueName = aws_sqs_queue.inbound_dlq[0].name
+  }
+
+  tags = merge(
+    var.core_tags,
+    { "scm:file" = "aws/global/ses/inbound-forwarding.tf" },
+  )
+}
+
+resource "aws_cloudwatch_metric_alarm" "worker_errors" {
+  count               = local.inbound_enabled ? 1 : 0
+  alarm_name          = "tellerstech-ses-inbound-worker-errors"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  metric_name         = "Errors"
+  namespace           = "AWS/Lambda"
+  period              = 300
+  statistic           = "Sum"
+  threshold           = 1
+  treat_missing_data  = "notBreaching"
+  alarm_description   = "SES inbound worker Lambda errors"
+  alarm_actions       = [aws_sns_topic.inbound_alerts[0].arn]
+  ok_actions          = [aws_sns_topic.inbound_alerts[0].arn]
+
+  dimensions = {
+    FunctionName = aws_lambda_function.forward_mail[0].function_name
+  }
+
+  tags = merge(
+    var.core_tags,
+    { "scm:file" = "aws/global/ses/inbound-forwarding.tf" },
+  )
+}
+
+resource "aws_cloudwatch_metric_alarm" "gate_errors" {
+  count               = local.inbound_enabled ? 1 : 0
+  alarm_name          = "tellerstech-ses-inbound-gate-errors"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  metric_name         = "Errors"
+  namespace           = "AWS/Lambda"
+  period              = 300
+  statistic           = "Sum"
+  threshold           = 1
+  treat_missing_data  = "notBreaching"
+  alarm_description   = "SES inbound gate Lambda errors"
+  alarm_actions       = [aws_sns_topic.inbound_alerts[0].arn]
+  ok_actions          = [aws_sns_topic.inbound_alerts[0].arn]
+
+  dimensions = {
+    FunctionName = aws_lambda_function.gate_mail[0].function_name
+  }
+
+  tags = merge(
+    var.core_tags,
+    { "scm:file" = "aws/global/ses/inbound-forwarding.tf" },
+  )
+}

--- a/aws/global/ses/lambda/forward_mail.py
+++ b/aws/global/ses/lambda/forward_mail.py
@@ -1,0 +1,341 @@
+"""
+SES inbound worker: validate, rate-limit, forward to Gmail, inject Roundcube copy.
+
+Triggered by SQS messages from S3 ObjectCreated notifications after SES stores
+raw MIME under inbound/<recipient>/<messageId>.
+"""
+
+from __future__ import annotations
+
+import email
+import email.policy
+import json
+import logging
+import os
+import smtplib
+import time
+import urllib.parse
+from datetime import datetime, timezone
+from email.utils import formataddr, parseaddr
+
+import boto3
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+s3 = boto3.client("s3")
+ses = boto3.client("ses")
+secretsmanager = boto3.client("secretsmanager")
+dynamodb = boto3.resource("dynamodb")
+cloudwatch = boto3.client("cloudwatch")
+
+SECRET_ARN = os.environ["RUNTIME_CONFIG_SECRET_ARN"]
+INBOUND_PREFIX = os.environ.get("INBOUND_PREFIX", "inbound/")
+QUARANTINE_PREFIX = os.environ.get("QUARANTINE_PREFIX", "quarantine/")
+TABLE_NAME = os.environ["LIMITS_TABLE_NAME"]
+INBOUND_BUCKET = os.environ["INBOUND_BUCKET"]
+MAX_BYTES = int(os.environ.get("MAX_MESSAGE_BYTES", str(10 * 1024 * 1024)))
+RATE_PER_RECIPIENT = int(os.environ.get("RATE_LIMIT_PER_RECIPIENT", "30"))
+RATE_GLOBAL = int(os.environ.get("RATE_LIMIT_GLOBAL", "100"))
+METRIC_NAMESPACE = os.environ.get("METRIC_NAMESPACE", "TellersTech/SESInbound")
+
+_config_cache: dict | None = None
+_table = None
+
+
+def _config() -> dict:
+    global _config_cache
+    if _config_cache is None:
+        raw = secretsmanager.get_secret_value(SecretId=SECRET_ARN)["SecretString"]
+        _config_cache = json.loads(raw)
+    return _config_cache
+
+
+def _table_resource():
+    global _table
+    if _table is None:
+        _table = dynamodb.Table(TABLE_NAME)
+    return _table
+
+
+def _allowlist() -> set[str]:
+    return {addr.strip().lower() for addr in _config().get("recipients") or [] if addr}
+
+
+def _put_metric(name: str, value: float = 1.0, unit: str = "Count") -> None:
+    try:
+        cloudwatch.put_metric_data(
+            Namespace=METRIC_NAMESPACE,
+            MetricData=[{"MetricName": name, "Value": value, "Unit": unit}],
+        )
+    except Exception:  # noqa: BLE001
+        logger.exception("Failed to put metric %s", name)
+
+
+def _recipient_from_key(key: str) -> str | None:
+    if not key.startswith(INBOUND_PREFIX):
+        return None
+    rest = key[len(INBOUND_PREFIX) :]
+    recipient = rest.split("/", 1)[0].strip().lower()
+    if recipient in _allowlist():
+        return recipient
+    return None
+
+
+def _message_id_from_key(key: str) -> str:
+    return key.rstrip("/").rsplit("/", 1)[-1]
+
+
+def _header(msg: email.message.Message, name: str, default: str = "") -> str:
+    return str(msg.get(name) or default).strip()
+
+
+def _verdict_fail(msg: email.message.Message, header_name: str) -> bool:
+    return _header(msg, header_name).upper() == "FAIL"
+
+
+def _auth_all_fail(msg: email.message.Message) -> bool:
+    spf = _header(msg, "X-SES-SPF-Verdict").upper()
+    dkim = _header(msg, "X-SES-DKIM-Verdict").upper()
+    dmarc = _header(msg, "X-SES-DMARC-Verdict").upper()
+    # Treat missing as GRAY (not fail). Quarantine only when every present check is FAIL
+    # and at least one FAIL exists; plan: SPF/DKIM/DMARC all FAIL.
+    statuses = [s for s in (spf, dkim, dmarc) if s]
+    if len(statuses) < 3:
+        return False
+    return all(s == "FAIL" for s in statuses)
+
+
+def _has_payload(msg: email.message.Message) -> bool:
+    if msg.is_multipart():
+        for part in msg.walk():
+            if part.get_content_maintype() == "multipart":
+                continue
+            if part.get_filename():
+                return True
+            payload = part.get_payload(decode=True)
+            if payload and payload.strip():
+                return True
+        return False
+    payload = msg.get_payload(decode=True)
+    return bool(payload and payload.strip())
+
+
+def _claim_idempotency(message_id: str) -> bool:
+    """Return True if this is the first time we process message_id."""
+    ttl = int(time.time()) + 7 * 24 * 3600
+    try:
+        _table_resource().put_item(
+            Item={
+                "pk": f"IDEM#{message_id}",
+                "sk": "v1",
+                "ttl": ttl,
+                "created_at": datetime.now(timezone.utc).isoformat(),
+            },
+            ConditionExpression="attribute_not_exists(pk)",
+        )
+        return True
+    except ClientError as exc:
+        if exc.response["Error"]["Code"] == "ConditionalCheckFailedException":
+            return False
+        raise
+
+
+def _release_idempotency(message_id: str) -> None:
+    """Allow SQS retries after a failed forward attempt."""
+    try:
+        _table_resource().delete_item(Key={"pk": f"IDEM#{message_id}", "sk": "v1"})
+    except Exception:  # noqa: BLE001
+        logger.exception("Failed to release idempotency for %s", message_id)
+
+
+def _increment_rate(key: str, limit: int) -> bool:
+    """
+    Increment hourly counter. Return True if still within limit after increment.
+    """
+    hour = datetime.now(timezone.utc).strftime("%Y%m%d%H")
+    pk = f"RATE#{key}#{hour}"
+    ttl = int(time.time()) + 2 * 3600
+    try:
+        resp = _table_resource().update_item(
+            Key={"pk": pk, "sk": "count"},
+            UpdateExpression="ADD #c :one SET #ttl = :ttl",
+            ExpressionAttributeNames={"#c": "count", "#ttl": "ttl"},
+            ExpressionAttributeValues={":one": 1, ":ttl": ttl, ":limit": limit},
+            ConditionExpression="attribute_not_exists(#c) OR #c < :limit",
+            ReturnValues="UPDATED_NEW",
+        )
+        logger.info("Rate %s => %s", pk, resp.get("Attributes"))
+        return True
+    except ClientError as exc:
+        if exc.response["Error"]["Code"] == "ConditionalCheckFailedException":
+            return False
+        raise
+
+
+def _quarantine(bucket: str, key: str, reason: str) -> None:
+    dest_key = f"{QUARANTINE_PREFIX}{key[len(INBOUND_PREFIX):]}" if key.startswith(INBOUND_PREFIX) else f"{QUARANTINE_PREFIX}{key}"
+    s3.copy_object(
+        Bucket=bucket,
+        CopySource={"Bucket": bucket, "Key": key},
+        Key=dest_key,
+        MetadataDirective="REPLACE",
+        Metadata={"quarantine-reason": reason[:256]},
+    )
+    logger.warning("Quarantined s3://%s/%s reason=%s", bucket, dest_key, reason)
+    _put_metric("Quarantined")
+
+
+def _build_forward_raw(original: email.message.Message, from_addr: str, gmail_dest: str) -> bytes:
+    msg = email.message_from_bytes(original.as_bytes(), policy=email.policy.SMTP)
+    original_from = msg.get("From", "unknown")
+    _, original_from_email = parseaddr(original_from)
+    display_name, _ = parseaddr(original_from)
+    if not display_name:
+        display_name = original_from_email or "Forwarded"
+
+    for header in (
+        "DKIM-Signature",
+        "DomainKey-Signature",
+        "Return-Path",
+        "Sender",
+        "Reply-To",
+        "To",
+        "From",
+        "Message-ID",
+    ):
+        if header in msg:
+            del msg[header]
+
+    msg["From"] = formataddr((f"{display_name} via TellersTech", from_addr))
+    msg["To"] = gmail_dest
+    if original_from_email:
+        msg["Reply-To"] = original_from
+    msg["X-Original-From"] = original_from
+    msg["X-Forwarded-To"] = gmail_dest
+    msg["X-Forwarded-For"] = from_addr
+    return msg.as_bytes()
+
+
+def _send_to_gmail(raw: bytes, from_addr: str, gmail_dest: str) -> None:
+    ses.send_raw_email(
+        Source=from_addr,
+        Destinations=[gmail_dest],
+        RawMessage={"Data": raw},
+    )
+    logger.info("Forwarded to Gmail as %s", from_addr)
+    _put_metric("ForwardedToGmail")
+
+
+def _deliver_local(raw_original: bytes, recipient: str) -> None:
+    smtp_cfg = (_config().get("smtp") or {})
+    host = smtp_cfg.get("host")
+    port = int(smtp_cfg.get("port") or 587)
+    password = (smtp_cfg.get("mailboxes") or {}).get(recipient)
+    if not host or not password:
+        raise RuntimeError("SMTP host/password missing in runtime config")
+
+    with smtplib.SMTP(host, port, timeout=30) as smtp:
+        smtp.ehlo()
+        smtp.starttls()
+        smtp.ehlo()
+        smtp.login(recipient, password)
+        smtp.sendmail(recipient, [recipient], raw_original)
+
+    logger.info("Delivered Roundcube copy for recipient via %s:%s", host, port)
+    _put_metric("DeliveredLocal")
+
+
+def _process(bucket: str, key: str) -> None:
+    recipient = _recipient_from_key(key)
+    if not recipient:
+        logger.warning("Skipping non-allowlisted key %s", key)
+        return
+
+    message_id = _message_id_from_key(key)
+    if not _claim_idempotency(message_id):
+        logger.info("Duplicate message_id %s; skipping", message_id)
+        _put_metric("DuplicateSkipped")
+        return
+
+    try:
+        head = s3.head_object(Bucket=bucket, Key=key)
+        size = int(head.get("ContentLength") or 0)
+        if size > MAX_BYTES:
+            _quarantine(bucket, key, "oversized")
+            _put_metric("Oversized")
+            return
+
+        raw = s3.get_object(Bucket=bucket, Key=key)["Body"].read()
+        mail_obj = email.message_from_bytes(raw, policy=email.policy.default)
+
+        if _verdict_fail(mail_obj, "X-SES-Virus-Verdict"):
+            _quarantine(bucket, key, "virus")
+            return
+
+        if _verdict_fail(mail_obj, "X-SES-Spam-Verdict") or _auth_all_fail(mail_obj):
+            _quarantine(bucket, key, "spam_or_auth_fail")
+            return
+
+        if not _header(mail_obj, "From") or not _header(mail_obj, "Date"):
+            _quarantine(bucket, key, "missing_from_or_date")
+            return
+
+        if not _has_payload(mail_obj):
+            _quarantine(bucket, key, "empty_payload")
+            return
+
+        if not _increment_rate(f"recipient#{recipient}", RATE_PER_RECIPIENT):
+            _quarantine(bucket, key, "flood_recipient")
+            _put_metric("FloodSuppressed")
+            return
+
+        if not _increment_rate("global", RATE_GLOBAL):
+            _quarantine(bucket, key, "flood_global")
+            _put_metric("FloodSuppressed")
+            return
+
+        gmail_dest = (_config().get("gmail_destination") or "").strip()
+        if not gmail_dest:
+            raise RuntimeError("gmail_destination missing in runtime config")
+
+        errors: list[str] = []
+        try:
+            _send_to_gmail(_build_forward_raw(mail_obj, recipient, gmail_dest), recipient, gmail_dest)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Gmail forward failed")
+            errors.append(f"gmail:{exc}")
+
+        try:
+            _deliver_local(raw, recipient)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Local delivery failed")
+            errors.append(f"local:{exc}")
+
+        if errors:
+            raise RuntimeError("; ".join(errors))
+    except Exception:
+        _release_idempotency(message_id)
+        raise
+
+
+def handler(event, _context):
+    for record in event.get("Records", []):
+        body = record.get("body") or ""
+        try:
+            payload = json.loads(body)
+        except json.JSONDecodeError:
+            logger.error("Invalid SQS body")
+            raise
+
+        # S3 event notification wrapped in SQS
+        for s3_record in payload.get("Records", []):
+            bucket = s3_record["s3"]["bucket"]["name"]
+            key = urllib.parse.unquote_plus(s3_record["s3"]["object"]["key"])
+            if key.startswith(QUARANTINE_PREFIX):
+                continue
+            logger.info("Processing s3://%s/%s", bucket, key)
+            _process(bucket, key)
+
+    return {"ok": True}

--- a/aws/global/ses/lambda/gate_mail.py
+++ b/aws/global/ses/lambda/gate_mail.py
@@ -1,0 +1,71 @@
+"""
+SES receipt-rule sync gate.
+
+Returns CONTINUE or STOP_RULE_SET. Virus FAIL and non-allowlisted recipients
+stop processing before S3 store / worker forward.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+
+import boto3
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+secretsmanager = boto3.client("secretsmanager")
+
+SECRET_ARN = os.environ["RUNTIME_CONFIG_SECRET_ARN"]
+
+_config_cache: dict | None = None
+
+
+def _config() -> dict:
+    global _config_cache
+    if _config_cache is None:
+        raw = secretsmanager.get_secret_value(SecretId=SECRET_ARN)["SecretString"]
+        _config_cache = json.loads(raw)
+    return _config_cache
+
+
+def _allowlist() -> set[str]:
+    return {addr.strip().lower() for addr in _config().get("recipients") or [] if addr}
+
+
+def _verdict(receipt: dict, name: str) -> str:
+    block = receipt.get(name) or {}
+    return str(block.get("status") or "GRAY").upper()
+
+
+def handler(event, _context):
+    """SES expects {\"disposition\": \"CONTINUE\"|\"STOP_RULE\"|\"STOP_RULE_SET\"}."""
+    logger.info("Gate event keys: %s", list(event.keys()))
+
+    records = event.get("Records") or [event]
+    allow = _allowlist()
+    if not allow:
+        logger.error("Runtime config has empty recipients allowlist; stopping")
+        return {"disposition": "STOP_RULE_SET"}
+
+    for record in records:
+        ses_block = record.get("ses") or event.get("ses") or {}
+        receipt = ses_block.get("receipt") or {}
+        mail = ses_block.get("mail") or {}
+
+        recipients = [
+            addr.strip().lower()
+            for addr in (receipt.get("recipients") or mail.get("destination") or [])
+            if addr
+        ]
+        if not recipients or not any(addr in allow for addr in recipients):
+            logger.warning("No allowlisted recipient in %s; STOP_RULE_SET", recipients)
+            return {"disposition": "STOP_RULE_SET"}
+
+        if _verdict(receipt, "virusVerdict") == "FAIL":
+            logger.warning("Virus FAIL; STOP_RULE_SET")
+            return {"disposition": "STOP_RULE_SET"}
+
+    return {"disposition": "CONTINUE"}

--- a/aws/global/ses/outputs.tf
+++ b/aws/global/ses/outputs.tf
@@ -17,3 +17,72 @@ output "ses_feedback_topic_name" {
   description = "Name of the SES bounce/complaint feedback SNS topic"
   value       = aws_sns_topic.ses_feedback.name
 }
+
+output "inbound_forwarding_enabled" {
+  description = "Whether SES inbound + Lambda forwarding is provisioned"
+  value       = var.enable_inbound_forwarding
+}
+
+output "inbound_gate_lambda_name" {
+  description = "Sync SES receipt gate Lambda name"
+  value       = try(aws_lambda_function.gate_mail[0].function_name, null)
+}
+
+output "inbound_worker_lambda_name" {
+  description = "Async inbound worker Lambda name"
+  value       = try(aws_lambda_function.forward_mail[0].function_name, null)
+}
+
+output "inbound_s3_bucket" {
+  description = "S3 bucket storing raw inbound and quarantine MIME"
+  value       = try(aws_s3_bucket.ses_inbound[0].id, null)
+}
+
+output "inbound_sqs_queue_url" {
+  description = "SQS queue URL feeding the inbound worker"
+  value       = try(aws_sqs_queue.inbound[0].id, null)
+}
+
+output "inbound_dlq_url" {
+  description = "Dead-letter queue URL for failed inbound processing"
+  value       = try(aws_sqs_queue.inbound_dlq[0].id, null)
+}
+
+output "inbound_runtime_config_secret_name" {
+  description = "Secrets Manager secret name for runtime config (recipients, gmail_destination, smtp)"
+  value       = try(aws_secretsmanager_secret.runtime_config[0].name, null)
+}
+
+output "inbound_runtime_config_secret_arn" {
+  description = "Secrets Manager secret ARN for runtime config"
+  value       = try(aws_secretsmanager_secret.runtime_config[0].arn, null)
+}
+
+output "inbound_alerts_topic_arn" {
+  description = "SNS topic for inbound flood/error alarms"
+  value       = try(aws_sns_topic.inbound_alerts[0].arn, null)
+}
+
+output "ses_inbound_mx_records" {
+  description = "MX to publish in DirectAdmin DNS for the receiving domain after apply + runtime secret is populated"
+  value = var.enable_inbound_forwarding ? [
+    {
+      priority = 10
+      hostname = "inbound-smtp.${data.aws_region.current.name}.amazonaws.com"
+    }
+  ] : []
+}
+
+output "inbound_cutover_checklist" {
+  description = "Post-apply steps (no mailbox addresses — those live in TFC + Secrets Manager)"
+  value = var.enable_inbound_forwarding ? [
+    "1. Set TFC sensitive variable inbound_recipients (HCL list of allowlisted addresses)",
+    "2. Optionally set TFC sensitive inbound_alert_email for alarm SNS email confirm",
+    "3. Put runtime JSON in Secrets Manager secret tellerstech/ses-inbound/runtime-config (recipients, gmail_destination, alert_email, smtp.host/port/mailboxes)",
+    "4. Confirm allowlisted mailboxes exist in DirectAdmin for Roundcube",
+    "5. Delete DirectAdmin forwarders that pointed those addresses at Gmail",
+    "6. In DirectAdmin DNS for the domain, set MX 10 to inbound-smtp.<region>.amazonaws.com and remove the old MX",
+    "7. Send a test from an external account; verify Gmail + Roundcube + gate/worker logs; confirm SNS alarm email if configured",
+    "8. Rollback: restore previous MX; set enable_inbound_forwarding=false or deactivate the receipt rule set",
+  ] : []
+}

--- a/aws/global/ses/variables.tf
+++ b/aws/global/ses/variables.tf
@@ -4,8 +4,9 @@ variable "core_tags" {
 }
 
 variable "tellerstech_email" {
-  description = "TellersTech email address for forwarding notifications"
+  description = "Legacy SNS email endpoint for the old forwarding-notification topic (TFC sensitive; leave empty to skip)"
   type        = string
+  sensitive   = true
   default     = ""
 }
 
@@ -16,7 +17,73 @@ variable "ses_identity" {
 }
 
 variable "ses_feedback_endpoint" {
-  description = "HTTPS webhook that receives SES bounce/complaint SNS notifications. Suppression is applied globally by email, so one endpoint covers all lists (OCB + SIW)."
+  description = "HTTPS webhook that receives SES bounce/complaint SNS notifications"
   type        = string
   default     = "https://www.tellerstech.com/wp-json/tellerstech/v1/ocb-ses-notification"
+}
+
+variable "enable_inbound_forwarding" {
+  description = "Provision SES inbound receive + gated Lambda forward to Gmail / Roundcube"
+  type        = bool
+  default     = false
+}
+
+variable "inbound_recipients" {
+  description = "Allowlisted local addresses for SES receipt rules (set in TFC as a sensitive HCL list; never commit values)"
+  type        = list(string)
+  sensitive   = true
+  default     = []
+
+  validation {
+    condition     = !var.enable_inbound_forwarding || length(var.inbound_recipients) > 0
+    error_message = "When enable_inbound_forwarding is true, set inbound_recipients in the Terraform Cloud variable set (sensitive HCL list)."
+  }
+}
+
+variable "inbound_alert_email" {
+  description = "Optional SNS email subscriber for inbound flood/error alarms (TFC sensitive; leave empty to subscribe manually)"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "inbound_mail_retention_days" {
+  description = "Days to retain raw inbound / quarantine MIME objects in S3"
+  type        = number
+  default     = 30
+}
+
+variable "inbound_max_message_bytes" {
+  description = "Max raw message size the worker will forward (bytes)"
+  type        = number
+  default     = 10485760 # 10 MiB
+}
+
+variable "inbound_rate_limit_per_recipient" {
+  description = "Max messages per recipient per hour before flood quarantine"
+  type        = number
+  default     = 30
+}
+
+variable "inbound_rate_limit_global" {
+  description = "Max messages across all allowlisted recipients per hour before flood quarantine"
+  type        = number
+  default     = 100
+}
+
+variable "inbound_worker_reserved_concurrency" {
+  description = "Reserved concurrency for the inbound worker Lambda (burst control)"
+  type        = number
+  default     = 2
+}
+
+variable "inbound_tls_policy" {
+  description = "SES receipt TLS policy: Require or Optional"
+  type        = string
+  default     = "Require"
+
+  validation {
+    condition     = contains(["Require", "Optional"], var.inbound_tls_policy)
+    error_message = "inbound_tls_policy must be Require or Optional."
+  }
 }

--- a/aws/global/variables.tf
+++ b/aws/global/variables.tf
@@ -39,7 +39,28 @@ variable "billing_threshold_critical" {
 }
 
 variable "tellerstech_email" {
-  description = "TellersTech email address for SES forwarding notifications"
+  description = "Legacy SNS email for the old forwarding-notification topic (TFC sensitive)"
   type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "enable_inbound_forwarding" {
+  description = "Provision SES inbound receive + gated Lambda forward"
+  type        = bool
+  default     = false
+}
+
+variable "inbound_recipients" {
+  description = "Allowlisted addresses for SES receipt rules (TFC sensitive HCL list; never commit)"
+  type        = list(string)
+  sensitive   = true
+  default     = []
+}
+
+variable "inbound_alert_email" {
+  description = "Optional SNS email for inbound alarms (TFC sensitive)"
+  type        = string
+  sensitive   = true
   default     = ""
 }

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -46,8 +46,11 @@ module "global" {
   billing_threshold_warning  = 75  # Alert at $75
   billing_threshold_critical = 100 # Critical at $100
 
-  # SES email forwarding - uses tellerstech_email from credentials.tf
-  tellerstech_email = var.tellerstech_email
+  # SES — set inbound_* in TFC sensitive variable set before enabling
+  tellerstech_email         = var.tellerstech_email
+  enable_inbound_forwarding = var.enable_inbound_forwarding
+  inbound_recipients        = var.inbound_recipients
+  inbound_alert_email       = var.inbound_alert_email
 }
 
 ######################################################

--- a/aws/versions.tf
+++ b/aws/versions.tf
@@ -4,6 +4,10 @@ terraform {
       source  = "hashicorp/aws"
       version = "~>5.0"
     }
+    archive = {
+      source  = "hashicorp/archive"
+      version = "~>2.0"
+    }
   }
   required_version = ">= 1.15.0"
 }


### PR DESCRIPTION
## Summary

- Adds SES inbound receive with a sync validation gate (allowlist + virus stop), S3 storage, SQS buffering, and a worker that re-sends to Gmail as a verified domain identity while injecting a local Roundcube copy over SMTP :587.
- Flood controls: per-recipient and global hourly rate limits (DynamoDB), reserved Lambda concurrency, quarantine prefix, DLQ, and CloudWatch alarms.
- Secret hygiene for this public repo: mailbox / Gmail / alert addresses are **not** in git. They live in Terraform Cloud sensitive variables and Secrets Manager.

## Setup guide

Do this in order. Use placeholders only in docs; put real values only in TFC and Secrets Manager.

### 1. Terraform Cloud variables (sensitive)

In the `wbat-terraform-aws` workspace (or a variable set attached to it), set:

| Variable | Type | Notes |
|---|---|---|
| `enable_inbound_forwarding` | `true` (boolean) | Off by default in code |
| `inbound_recipients` | sensitive HCL list | Allowlisted local addresses, e.g. `["user1@example.com", "user2@example.com"]` |
| `inbound_alert_email` | sensitive string (optional) | SNS alarm subscriber; leave empty to subscribe manually later |
| `tellerstech_email` / `personal_email` | sensitive (if used elsewhere) | Prefer TFC over committing `credentials.auto.tfvars` |

### 2. Apply Terraform

Merge/apply this PR so the stack creates:

- Secrets Manager secret `tellerstech/ses-inbound/runtime-config` (empty seed)
- S3 inbound bucket, SQS + DLQ, DynamoDB limits table
- Gate + worker Lambdas, SES receipt rule set, alarm SNS topic

Confirm outputs:

- `ses_inbound_mx_records`
- `ses_inbound_runtime_config_secret_name`
- `ses_inbound_cutover_checklist`
- `ses_inbound_alerts_topic_arn`

### 3. Populate Secrets Manager

Edit secret `tellerstech/ses-inbound/runtime-config` (Terraform ignores later `secret_string` changes):

```json
{
  "gmail_destination": "your-gmail@example.com",
  "alert_email": "alerts@example.com",
  "recipients": [
    "user1@example.com",
    "user2@example.com"
  ],
  "smtp": {
    "host": "mail.example.com",
    "port": 587,
    "mailboxes": {
      "user1@example.com": "REPLACE_WITH_MAILBOX_PASSWORD",
      "user2@example.com": "REPLACE_WITH_MAILBOX_PASSWORD"
    }
  }
}
```

Requirements:

- `recipients` must match the TFC `inbound_recipients` list (same addresses).
- SMTP host must accept authenticated submission on port **587** (AWS blocks port 25 from Lambda).
- Mailboxes must already exist in DirectAdmin for Roundcube.

### 4. Confirm SES domain receiving

In SES (us-east-1):

- Domain identity for the receiving domain is verified.
- Account can receive email in this region.
- Easy DKIM (and ideally custom MAIL FROM) is set for outbound re-sends to Gmail.

### 5. DirectAdmin cutover

1. Delete any DirectAdmin **forwarders** that previously sent allowlisted addresses to Gmail (the Lambda replaces them).
2. Keep the mailboxes themselves (Roundcube copies still land there).
3. In DirectAdmin DNS for the domain, set:

   - `MX 10 inbound-smtp.us-east-1.amazonaws.com`

   Remove the old DirectAdmin MX for that domain.
4. If you set `inbound_alert_email`, confirm the SNS subscription email.
5. Send a test from an **external** account to an allowlisted address.
6. Verify: Gmail inbox, Roundcube copy, gate/worker CloudWatch logs, no `554 Email address is not verified` bounce.

### 6. Behaviour reference

| Case | Result |
|---|---|
| Virus FAIL | Gate stops; nothing stored/forwarded |
| Spam FAIL or SPF+DKIM+DMARC all FAIL | Quarantine in S3 only |
| Over rate limit (30/recipient/hr or 100 global/hr) | Quarantine + `FloodSuppressed` alarm |
| Unknown address on the domain | Catch-all bounce |
| Happy path | Gmail via SES `SendRawEmail` + Roundcube via SMTP 587 |

### 7. Rollback

1. Restore previous MX records in DirectAdmin DNS.
2. Set `enable_inbound_forwarding = false` and apply, or deactivate the SES receipt rule set in the console.

## Test plan

- [ ] TFC vars set; apply succeeds with `enable_inbound_forwarding=true`
- [ ] Runtime secret populated; no real addresses appear in this repo/`git grep`
- [ ] External send → Gmail + Roundcube
- [ ] Non-allowlisted address on domain bounces
- [ ] Flood burst past cap → quarantine + alarm
- [ ] Worker/gate error or DLQ depth → SNS alert
- [ ] MX rollback restores DirectAdmin receiving


Made with [Cursor](https://cursor.com)