### PR TITLE
feat(tfc): add SES Inbound variable set for AWS workspace

### DIFF
--- a/tfc/tfc-variable-set-ses-inbound.tf
+++ b/tfc/tfc-variable-set-ses-inbound.tf
@@ -1,0 +1,54 @@
+# SES inbound allowlist / alerts — AWS workspace only.
+# Values are set in the TFC UI (ignore_changes); nothing sensitive belongs in git.
+
+resource "tfe_variable_set" "ses_inbound" {
+  name         = "SES Inbound"
+  description  = "SES inbound receive/forward variables for the AWS workspace (set values in TFC UI)"
+  organization = tfe_organization.wbat.id
+}
+
+resource "tfe_variable" "enable_inbound_forwarding" {
+  key             = "enable_inbound_forwarding"
+  value           = "false"
+  category        = "terraform"
+  hcl             = true
+  sensitive       = false
+  description     = "When true, provision SES inbound gate/worker and receipt rules"
+  variable_set_id = tfe_variable_set.ses_inbound.id
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}
+
+resource "tfe_variable" "inbound_recipients" {
+  key             = "inbound_recipients"
+  value           = "[]"
+  category        = "terraform"
+  hcl             = true
+  sensitive       = true
+  description     = "Allowlisted local addresses for SES receipt rules (HCL list)"
+  variable_set_id = tfe_variable_set.ses_inbound.id
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}
+
+resource "tfe_variable" "inbound_alert_email" {
+  key             = "inbound_alert_email"
+  value           = ""
+  category        = "terraform"
+  sensitive       = true
+  description     = "Optional SNS email subscriber for inbound flood/error alarms"
+  variable_set_id = tfe_variable_set.ses_inbound.id
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}
+
+resource "tfe_workspace_variable_set" "aws_ses_inbound" {
+  workspace_id    = tfe_workspace.aws.id
+  variable_set_id = tfe_variable_set.ses_inbound.id
+}


### PR DESCRIPTION
## Summary
- Creates a **SES Inbound** TFC variable set and attaches it to `wbat-terraform-aws` only.
- Declares `enable_inbound_forwarding`, `inbound_recipients` (sensitive HCL), and `inbound_alert_email` (sensitive).
- Seeds empty/`false` defaults with `ignore_changes` so real values are set in the TFC UI (nothing sensitive in git).

## Why
PR #77 documented these as manual TFC vars, but they were never declared in the `tfc/` workspace, so they did not show up after apply.

## After merge / apply (`wbat-terraform-tfc`)
1. Open variable set **SES Inbound** (or AWS workspace → Variables).
2. Set `inbound_recipients` to an HCL list of allowlisted addresses.
3. Optionally set `inbound_alert_email`.
4. Set `enable_inbound_forwarding = true`.
5. Run/apply **wbat-terraform-aws**, then populate Secrets Manager `tellerstech/ses-inbound/runtime-config` and cut over MX (see #77).

## Test plan
- [ ] `tfc` apply creates variable set and attaches to AWS workspace
- [ ] Vars visible on `wbat-terraform-aws`
- [ ] No real email addresses in this PR


Made with [Cursor](https://cursor.com)