### PR TITLE
feat(mail): DirectAdmin SES pipe forward to Gmail (keep MX on DA)

### DIFF
--- a/aws/global/iam/role-WBAT_Main_Server.tf
+++ b/aws/global/iam/role-WBAT_Main_Server.tf
@@ -116,6 +116,34 @@ resource "aws_iam_role_policy" "WBAT_Main_Server-SNSReadOnly" {
   })
 }
 
+# DirectAdmin pipe → SES SendRawEmail (Gmail copy). MX stays on DirectAdmin.
+# Secret: tellerstech/ses-gmail-forward/runtime-config (random suffix on ARN).
+resource "aws_iam_role_policy" "WBAT_Main_Server-SesGmailForward" {
+  name = "SesGmailForward"
+  role = aws_iam_role.WBAT_Main_Server.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "SesSendAsVerifiedIdentity"
+        Effect   = "Allow"
+        Action   = ["ses:SendRawEmail", "ses:SendEmail"]
+        Resource = "*"
+      },
+      {
+        Sid    = "ReadForwardRuntimeConfig"
+        Effect = "Allow"
+        Action = [
+          "secretsmanager:GetSecretValue",
+          "secretsmanager:DescribeSecret"
+        ]
+        Resource = "arn:aws:secretsmanager:us-east-1:${data.aws_caller_identity.current.account_id}:secret:tellerstech/ses-gmail-forward/runtime-config*"
+      }
+    ]
+  })
+}
+
 resource "aws_iam_instance_profile" "WBAT_Main_Server" {
   name = "WBAT_Main_Server"
   role = aws_iam_role.WBAT_Main_Server.name

--- a/aws/global/outputs.tf
+++ b/aws/global/outputs.tf
@@ -71,3 +71,8 @@ output "ses_inbound_alerts_topic_arn" {
   value       = module.ses.inbound_alerts_topic_arn
   description = "SNS topic for inbound flood/error alarms"
 }
+
+output "ses_da_gmail_forward_secret_name" {
+  value       = module.ses.da_gmail_forward_secret_name
+  description = "Secrets Manager secret for DirectAdmin → SES Gmail pipe (MX stays on DA)"
+}

--- a/aws/global/ses/da-gmail-forward.tf
+++ b/aws/global/ses/da-gmail-forward.tf
@@ -1,0 +1,33 @@
+# DirectAdmin → SES Gmail forward (MX stays on DirectAdmin).
+#
+# Runtime config secret is always provisioned. Populate in AWS console / CLI;
+# Terraform ignores secret_string changes after create. No addresses in git.
+
+resource "aws_secretsmanager_secret" "da_gmail_forward" {
+  name        = "tellerstech/ses-gmail-forward/runtime-config"
+  description = "DA pipe forward config: recipients, gmail_destination, rate limits (no MX change)"
+
+  tags = merge(
+    var.core_tags,
+    {
+      "Name"     = "TellersTech DA SES Gmail Forward Config"
+      "scm:file" = "aws/global/ses/da-gmail-forward.tf"
+    },
+  )
+}
+
+resource "aws_secretsmanager_secret_version" "da_gmail_forward" {
+  secret_id = aws_secretsmanager_secret.da_gmail_forward.id
+
+  secret_string = jsonencode({
+    gmail_destination                 = ""
+    recipients                        = []
+    rate_limit_per_recipient_per_hour = 30
+    rate_limit_global_per_hour        = 100
+    max_message_bytes                 = 10485760
+  })
+
+  lifecycle {
+    ignore_changes = [secret_string]
+  }
+}

--- a/aws/global/ses/inbound-forwarding.tf
+++ b/aws/global/ses/inbound-forwarding.tf
@@ -1,14 +1,11 @@
 # SES inbound receive → sync gate → S3 → SQS → worker → Gmail + Roundcube.
 #
-# Cutover (no mailbox addresses in this public repo):
-#   1. Set TFC sensitive var inbound_recipients (HCL list)
-#   2. Populate Secrets Manager runtime-config JSON (see secret name output)
-#   3. terraform apply
-#   4. Remove DirectAdmin Gmail forwarders for allowlisted addresses
-#   5. Point domain MX at SES inbound (see ses_inbound_mx_records output)
-#   6. Test from an external account; check Gmail, Roundcube, Lambda logs
+# DEPRECATED for TellersTech mail: prefer DirectAdmin MX + scripts/directadmin/
+# ses_gmail_forward.py so Postfix/Exim keeps inbound. Leave
+# enable_inbound_forwarding = false unless you intentionally point MX at SES.
 #
-# Roundcube copies use SMTP submission :587 (AUTH). Port 25 from Lambda is blocked.
+# If enabled, MX must point at SES (DirectAdmin is no longer primary inbound).
+# Roundcube copies then require SMTP :587 reinject (port 25 from Lambda is blocked).
 
 data "aws_region" "current" {}
 

--- a/aws/global/ses/outputs.tf
+++ b/aws/global/ses/outputs.tf
@@ -64,7 +64,7 @@ output "inbound_alerts_topic_arn" {
 }
 
 output "ses_inbound_mx_records" {
-  description = "MX to publish in DirectAdmin DNS for the receiving domain after apply + runtime secret is populated"
+  description = "Only if enable_inbound_forwarding=true (not used when DirectAdmin owns MX)"
   value = var.enable_inbound_forwarding ? [
     {
       priority = 10
@@ -74,15 +74,29 @@ output "ses_inbound_mx_records" {
 }
 
 output "inbound_cutover_checklist" {
-  description = "Post-apply steps (no mailbox addresses — those live in TFC + Secrets Manager)"
+  description = "Legacy SES-receive cutover (prefer DA pipe forward; keep enable_inbound_forwarding=false)"
   value = var.enable_inbound_forwarding ? [
+    "WARNING: Enabling this moves inbound MX to SES; DirectAdmin will not be primary MX.",
+    "Prefer scripts/directadmin/ses_gmail_forward.py with MX left on DirectAdmin instead.",
     "1. Set TFC sensitive variable inbound_recipients (HCL list of allowlisted addresses)",
     "2. Optionally set TFC sensitive inbound_alert_email for alarm SNS email confirm",
-    "3. Put runtime JSON in Secrets Manager secret tellerstech/ses-inbound/runtime-config (recipients, gmail_destination, alert_email, smtp.host/port/mailboxes)",
-    "4. Confirm allowlisted mailboxes exist in DirectAdmin for Roundcube",
+    "3. Put runtime JSON in Secrets Manager secret tellerstech/ses-inbound/runtime-config",
+    "4. Confirm allowlisted mailboxes exist in DirectAdmin for Roundcube reinject",
     "5. Delete DirectAdmin forwarders that pointed those addresses at Gmail",
-    "6. In DirectAdmin DNS for the domain, set MX 10 to inbound-smtp.<region>.amazonaws.com and remove the old MX",
-    "7. Send a test from an external account; verify Gmail + Roundcube + gate/worker logs; confirm SNS alarm email if configured",
-    "8. Rollback: restore previous MX; set enable_inbound_forwarding=false or deactivate the receipt rule set",
-  ] : []
+    "6. Set MX 10 to inbound-smtp.<region>.amazonaws.com (replaces DA as inbound)",
+    "7. Test externally; verify Gmail + Roundcube reinject + Lambda logs",
+    "8. Rollback: restore previous MX; set enable_inbound_forwarding=false",
+    ] : [
+    "enable_inbound_forwarding is false — use DirectAdmin MX + ses_gmail_forward.py (see scripts/directadmin/ses_gmail_forward.md)",
+  ]
+}
+
+output "da_gmail_forward_secret_name" {
+  description = "Secrets Manager secret for DirectAdmin → SES Gmail pipe forward"
+  value       = aws_secretsmanager_secret.da_gmail_forward.name
+}
+
+output "da_gmail_forward_secret_arn" {
+  description = "Secrets Manager ARN for DirectAdmin → SES Gmail pipe forward"
+  value       = aws_secretsmanager_secret.da_gmail_forward.arn
 }

--- a/scripts/directadmin/README.md
+++ b/scripts/directadmin/README.md
@@ -2,6 +2,11 @@
 
 Install on **both** DirectAdmin servers (`server` and `server2`) under `/usr/local/directadmin/scripts/custom/`.
 
+## Related: Gmail copy via SES (MX stays on DA)
+
+See [ses_gmail_forward.md](./ses_gmail_forward.md) and `ses_gmail_forward.py`. That path
+keeps inbound MX on DirectAdmin and pipes a SES-authenticated copy to Gmail.
+
 ## Hooks
 
 | File | DirectAdmin event |

--- a/scripts/directadmin/README.md
+++ b/scripts/directadmin/README.md
@@ -4,8 +4,9 @@ Install on **both** DirectAdmin servers (`server` and `server2`) under `/usr/loc
 
 ## Related: Gmail copy via SES (MX stays on DA)
 
-See [ses_gmail_forward.md](./ses_gmail_forward.md) and `ses_gmail_forward.py`. That path
-keeps inbound MX on DirectAdmin and pipes a SES-authenticated copy to Gmail.
+Most seamless: DA **Forwarders** → `| /usr/local/bin/ses-gmail-forward.py`  
+(see [ses_gmail_forward.md](./ses_gmail_forward.md)). Keep the mailbox for Roundcube;
+do not forward to Gmail over the SES smart host.
 
 ## Hooks
 

--- a/scripts/directadmin/ses_gmail_forward.md
+++ b/scripts/directadmin/ses_gmail_forward.md
@@ -1,30 +1,44 @@
-# DirectAdmin → Gmail via SES (keep MX on DirectAdmin)
+# DirectAdmin → Gmail via SES (most seamless DA setup)
 
-Inbound mail stays on **DirectAdmin / Exim**. This pipe sends an authenticated
-**copy** to Gmail through SES so you do not hit `554 Email address is not verified`
-(that happens when Exim relays a forward through SES with the original From).
+**Keep MX on DirectAdmin.** Use the normal **Forwarders** UI with a pipe.
+Do not forward to a Gmail address through the SES SMTP smart host (that causes
+`554 Email address is not verified`).
 
-**Do not** point the domain MX at SES for this flow.
+## What you do in DirectAdmin (ongoing)
+
+For each mailbox that should also land in Gmail:
+
+1. **E-Mail Accounts** — keep/create the account (Roundcube stays as today).
+2. **Forwarders** → Create forwarder  
+   - From: the local address (same as the mailbox)  
+   - To: `| /usr/local/bin/ses-gmail-forward.py`  
+     (leading pipe is required)
+3. Confirm DA still delivers to the mailbox (account + forwarder). If a forwarder
+   *replaces* delivery on your DA version, use a destination that keeps local
+   delivery as well (DA/Exim often stores `user: user, |/path/script` in aliases).
+
+That is the whole day-to-day UX. Allowlist / Gmail destination live in AWS
+Secrets Manager (not in git).
 
 ## Flow
 
 ```
-Internet → MX DirectAdmin → local mailbox (Roundcube)
-                         ↘ unseen pipe → ses-gmail-forward.py → SES → Gmail
+Internet → MX DirectAdmin → mailbox (Roundcube)
+                         ↘ DA Forwarder pipe → ses-gmail-forward.py → SES → Gmail
 ```
 
-SES `From` = allowlisted local address (verified domain). `Reply-To` = original sender.
+SES sends as the local allowlisted address; `Reply-To` is the original sender.
 
-## 1. Terraform / IAM (this repo)
+## One-time server setup
 
-Apply the AWS workspace so that:
+### 1. Terraform
 
-- Instance role `WBAT_Main_Server` can `ses:SendRawEmail` and read the secret
-- Secret `tellerstech/ses-gmail-forward/runtime-config` exists
+Apply AWS workspace so `WBAT_Main_Server` can `ses:SendRawEmail` and read
+`tellerstech/ses-gmail-forward/runtime-config`.
 
-## 2. Populate Secrets Manager
+### 2. Secrets Manager
 
-Edit `tellerstech/ses-gmail-forward/runtime-config` (values only in AWS, not git):
+Populate `tellerstech/ses-gmail-forward/runtime-config`:
 
 ```json
 {
@@ -39,81 +53,44 @@ Edit `tellerstech/ses-gmail-forward/runtime-config` (values only in AWS, not git
 }
 ```
 
-## 3. Install script on the mail server
+`recipients` must include every address you create a pipe forwarder for.
+
+### 3. Install the pipe binary
 
 ```bash
 install -m 755 scripts/directadmin/ses_gmail_forward.py \
   /usr/local/bin/ses-gmail-forward.py
-
-mkdir -p /var/lib/ses-gmail-forward /var/log
+mkdir -p /var/lib/ses-gmail-forward
 touch /var/log/ses-gmail-forward.log
 chmod 750 /var/lib/ses-gmail-forward
-```
-
-Needs Python 3 + `boto3` (or a venv) and the instance profile credentials.
-
-```bash
 python3 -c 'import boto3; print(boto3.__version__)'
-# Optional smoke test (paste a tiny .eml on stdin):
-# printf 'From: a@example.com\nDate: Tue, 21 Jul 2026 12:00:00 +0000\nSubject: t\n\nbody\n' \
-#   | /usr/local/bin/ses-gmail-forward.py user1@example.com
 ```
 
-## 4. Wire Exim / DirectAdmin (unseen pipe)
+### 4. Remove broken Gmail address forwarders
 
-Deliver **locally as today**, and add an **unseen** pipe so the original is not
-stolen by the pipe.
+Delete Forwarders whose destination was a Gmail address (SES smart-host path).
 
-### Option A — Exim system filter (recommended pattern)
+### 5. Test
 
-On the DA box, add a system filter snippet that pipes only after local routing
-(exact path varies by DA/Exim layout). Conceptually:
+1. External mail → allowlisted address  
+2. Roundcube has it  
+3. Gmail has the SES copy  
+4. `/var/log/ses-gmail-forward.log` shows success  
 
-```
-# Pseudocode — adapt to your Exim system_filter / DA custom router docs.
-# For each message where $local_part@$domain is allowlisted on the server,
-# also run:
-unseen pipe "/usr/local/bin/ses-gmail-forward.py ${local_part}@${domain}"
-```
+## Why a small script is still required
 
-Because the script no-ops for non-allowlisted recipients, you may pipe all
-local mail for the domain and keep the allowlist only in Secrets Manager.
+DirectAdmin Forwarders only send to **addresses** or **pipes**. They cannot
+call Lambda/HTTP. A pipe to this script is the DA-native way to reach SES’s
+API (instance role) without changing MX.
 
-### Option B — Per-address alias (local + pipe)
-
-In the domain aliases file (DA virtual aliases), use a dual destination so
-mail is saved **and** piped (syntax depends on Exim/DA version), e.g. concept:
-
-```
-localpart: localpart, |/usr/local/bin/ses-gmail-forward.py localpart@example.com
-```
-
-Confirm with a test that Roundcube still gets the message if the pipe fails
-(script exits `0` on SES errors so Exim should not bounce local delivery).
-
-### Remove broken Gmail forwarders
-
-Delete DirectAdmin forwarders that pointed allowlisted addresses at Gmail via
-the SES smart host (those caused the 554 unverified-From bounces).
-
-## 5. Test
-
-1. From an **external** account, mail an allowlisted address.
-2. Confirm Roundcube has the message (MX still DA).
-3. Confirm Gmail received the SES copy (`Reply-To` = original sender).
-4. Check `/var/log/ses-gmail-forward.log`.
-
-## 6. Leave SES inbound receive disabled
-
-`enable_inbound_forwarding` should stay **false**. That stack receives mail at
-SES MX and is the wrong model when DirectAdmin owns inbound.
+Leave `enable_inbound_forwarding = false` (SES-as-MX is a different model).
 
 ## Troubleshooting
 
 | Symptom | Likely cause |
 |---|---|
-| Nothing in Gmail | Recipient not in secret allowlist; check log |
-| `AccessDenied` on SES | Instance profile policy not applied / wrong role |
-| `Email address is not verified` | Sending as an address/domain not verified in SES |
-| Roundcube empty | Pipe replaced delivery instead of `unseen` — fix Exim/alias |
-| Flood of SES sends | Rate limits in secret; check `/var/lib/ses-gmail-forward` |
+| Nothing in Gmail | Address missing from secret `recipients`; check log |
+| Roundcube empty | Forwarder replaced mailbox delivery — keep local account + pipe |
+| `AccessDenied` | Instance profile IAM not applied |
+| `Email address is not verified` | Local From domain/address not verified in SES |
+| Script not run | Forwarder missing leading `\|` or wrong path |

--- a/scripts/directadmin/ses_gmail_forward.md
+++ b/scripts/directadmin/ses_gmail_forward.md
@@ -1,0 +1,119 @@
+# DirectAdmin → Gmail via SES (keep MX on DirectAdmin)
+
+Inbound mail stays on **DirectAdmin / Exim**. This pipe sends an authenticated
+**copy** to Gmail through SES so you do not hit `554 Email address is not verified`
+(that happens when Exim relays a forward through SES with the original From).
+
+**Do not** point the domain MX at SES for this flow.
+
+## Flow
+
+```
+Internet → MX DirectAdmin → local mailbox (Roundcube)
+                         ↘ unseen pipe → ses-gmail-forward.py → SES → Gmail
+```
+
+SES `From` = allowlisted local address (verified domain). `Reply-To` = original sender.
+
+## 1. Terraform / IAM (this repo)
+
+Apply the AWS workspace so that:
+
+- Instance role `WBAT_Main_Server` can `ses:SendRawEmail` and read the secret
+- Secret `tellerstech/ses-gmail-forward/runtime-config` exists
+
+## 2. Populate Secrets Manager
+
+Edit `tellerstech/ses-gmail-forward/runtime-config` (values only in AWS, not git):
+
+```json
+{
+  "gmail_destination": "your-gmail@example.com",
+  "recipients": [
+    "user1@example.com",
+    "user2@example.com"
+  ],
+  "rate_limit_per_recipient_per_hour": 30,
+  "rate_limit_global_per_hour": 100,
+  "max_message_bytes": 10485760
+}
+```
+
+## 3. Install script on the mail server
+
+```bash
+install -m 755 scripts/directadmin/ses_gmail_forward.py \
+  /usr/local/bin/ses-gmail-forward.py
+
+mkdir -p /var/lib/ses-gmail-forward /var/log
+touch /var/log/ses-gmail-forward.log
+chmod 750 /var/lib/ses-gmail-forward
+```
+
+Needs Python 3 + `boto3` (or a venv) and the instance profile credentials.
+
+```bash
+python3 -c 'import boto3; print(boto3.__version__)'
+# Optional smoke test (paste a tiny .eml on stdin):
+# printf 'From: a@example.com\nDate: Tue, 21 Jul 2026 12:00:00 +0000\nSubject: t\n\nbody\n' \
+#   | /usr/local/bin/ses-gmail-forward.py user1@example.com
+```
+
+## 4. Wire Exim / DirectAdmin (unseen pipe)
+
+Deliver **locally as today**, and add an **unseen** pipe so the original is not
+stolen by the pipe.
+
+### Option A — Exim system filter (recommended pattern)
+
+On the DA box, add a system filter snippet that pipes only after local routing
+(exact path varies by DA/Exim layout). Conceptually:
+
+```
+# Pseudocode — adapt to your Exim system_filter / DA custom router docs.
+# For each message where $local_part@$domain is allowlisted on the server,
+# also run:
+unseen pipe "/usr/local/bin/ses-gmail-forward.py ${local_part}@${domain}"
+```
+
+Because the script no-ops for non-allowlisted recipients, you may pipe all
+local mail for the domain and keep the allowlist only in Secrets Manager.
+
+### Option B — Per-address alias (local + pipe)
+
+In the domain aliases file (DA virtual aliases), use a dual destination so
+mail is saved **and** piped (syntax depends on Exim/DA version), e.g. concept:
+
+```
+localpart: localpart, |/usr/local/bin/ses-gmail-forward.py localpart@example.com
+```
+
+Confirm with a test that Roundcube still gets the message if the pipe fails
+(script exits `0` on SES errors so Exim should not bounce local delivery).
+
+### Remove broken Gmail forwarders
+
+Delete DirectAdmin forwarders that pointed allowlisted addresses at Gmail via
+the SES smart host (those caused the 554 unverified-From bounces).
+
+## 5. Test
+
+1. From an **external** account, mail an allowlisted address.
+2. Confirm Roundcube has the message (MX still DA).
+3. Confirm Gmail received the SES copy (`Reply-To` = original sender).
+4. Check `/var/log/ses-gmail-forward.log`.
+
+## 6. Leave SES inbound receive disabled
+
+`enable_inbound_forwarding` should stay **false**. That stack receives mail at
+SES MX and is the wrong model when DirectAdmin owns inbound.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| Nothing in Gmail | Recipient not in secret allowlist; check log |
+| `AccessDenied` on SES | Instance profile policy not applied / wrong role |
+| `Email address is not verified` | Sending as an address/domain not verified in SES |
+| Roundcube empty | Pipe replaced delivery instead of `unseen` — fix Exim/alias |
+| Flood of SES sends | Rate limits in secret; check `/var/lib/ses-gmail-forward` |

--- a/scripts/directadmin/ses_gmail_forward.py
+++ b/scripts/directadmin/ses_gmail_forward.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""
+DirectAdmin / Exim pipe: copy allowlisted inbound mail to Gmail via SES.
+
+MX stays on DirectAdmin (local delivery unchanged). Configure Exim/DA to also
+pipe a copy into this script (unseen). The script re-sends via SES as the
+local recipient (verified domain identity) with Reply-To = original From.
+
+Usage (Exim pipe):
+  unseen pipe \"/usr/local/bin/ses-gmail-forward.py ${local_part}@${domain}\"
+
+Config: Secrets Manager tellerstech/ses-gmail-forward/runtime-config
+  {
+    \"gmail_destination\": \"your-gmail@example.com\",
+    \"recipients\": [\"user1@example.com\", \"user2@example.com\"],
+    \"rate_limit_per_recipient_per_hour\": 30,
+    \"rate_limit_global_per_hour\": 100,
+    \"max_message_bytes\": 10485760
+  }
+
+Requires: boto3, instance profile with ses:SendRawEmail + secretsmanager:GetSecretValue.
+Exit 0 on success / intentional skip so Exim does not defer local mail.
+"""
+
+from __future__ import annotations
+
+import email
+import email.policy
+import json
+import logging
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from email.utils import formataddr, parseaddr
+from pathlib import Path
+
+import boto3
+from botocore.exceptions import ClientError
+
+LOG_PATH = os.environ.get("SES_GMAIL_FORWARD_LOG", "/var/log/ses-gmail-forward.log")
+SECRET_ID = os.environ.get(
+    "SES_GMAIL_FORWARD_SECRET",
+    "tellerstech/ses-gmail-forward/runtime-config",
+)
+STATE_DIR = Path(os.environ.get("SES_GMAIL_FORWARD_STATE", "/var/lib/ses-gmail-forward"))
+AWS_REGION = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+    handlers=[
+        logging.FileHandler(LOG_PATH),
+        logging.StreamHandler(sys.stderr),
+    ],
+)
+logger = logging.getLogger("ses-gmail-forward")
+
+secretsmanager = boto3.client("secretsmanager", region_name=AWS_REGION)
+ses = boto3.client("ses", region_name=AWS_REGION)
+
+_config_cache: dict | None = None
+_config_loaded_at = 0.0
+
+
+def _config() -> dict:
+    global _config_cache, _config_loaded_at
+    now = time.time()
+    if _config_cache is None or (now - _config_loaded_at) > 60:
+        raw = secretsmanager.get_secret_value(SecretId=SECRET_ID)["SecretString"]
+        _config_cache = json.loads(raw)
+        _config_loaded_at = now
+    return _config_cache
+
+
+def _allowlist(cfg: dict) -> set[str]:
+    return {a.strip().lower() for a in (cfg.get("recipients") or []) if a}
+
+
+def _rate_ok(key: str, limit: int) -> bool:
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    hour = datetime.now(timezone.utc).strftime("%Y%m%d%H")
+    path = STATE_DIR / f"rate-{key.replace('/', '_')}-{hour}.count"
+    try:
+        count = int(path.read_text().strip() or "0")
+    except FileNotFoundError:
+        count = 0
+    except OSError:
+        count = 0
+    if count >= limit:
+        return False
+    path.write_text(str(count + 1))
+    return True
+
+
+def _has_payload(msg: email.message.Message) -> bool:
+    if msg.is_multipart():
+        for part in msg.walk():
+            if part.get_content_maintype() == "multipart":
+                continue
+            if part.get_filename():
+                return True
+            payload = part.get_payload(decode=True)
+            if payload and payload.strip():
+                return True
+        return False
+    payload = msg.get_payload(decode=True)
+    return bool(payload and payload.strip())
+
+
+def _build_forward_raw(original: email.message.Message, from_addr: str, gmail_dest: str) -> bytes:
+    msg = email.message_from_bytes(original.as_bytes(), policy=email.policy.SMTP)
+    original_from = msg.get("From", "unknown")
+    _, original_from_email = parseaddr(original_from)
+    display_name, _ = parseaddr(original_from)
+    if not display_name:
+        display_name = original_from_email or "Forwarded"
+
+    for header in (
+        "DKIM-Signature",
+        "DomainKey-Signature",
+        "Return-Path",
+        "Sender",
+        "Reply-To",
+        "To",
+        "From",
+        "Message-ID",
+    ):
+        if header in msg:
+            del msg[header]
+
+    msg["From"] = formataddr((f"{display_name} via TellersTech", from_addr))
+    msg["To"] = gmail_dest
+    if original_from_email:
+        msg["Reply-To"] = original_from
+    msg["X-Original-From"] = original_from
+    msg["X-Forwarded-To"] = gmail_dest
+    msg["X-Forwarded-For"] = from_addr
+    return msg.as_bytes()
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        logger.error("Usage: ses-gmail-forward.py local@domain < message.eml")
+        return 0
+
+    recipient = argv[1].strip().lower()
+    raw = sys.stdin.buffer.read()
+    if not raw:
+        logger.warning("Empty stdin for %s; skip", recipient)
+        return 0
+
+    try:
+        cfg = _config()
+    except ClientError:
+        logger.exception("Failed to load runtime config")
+        return 0
+
+    if recipient not in _allowlist(cfg):
+        logger.info("Recipient not allowlisted; skip")
+        return 0
+
+    max_bytes = int(cfg.get("max_message_bytes") or 10 * 1024 * 1024)
+    if len(raw) > max_bytes:
+        logger.warning("Message oversized (%s bytes); skip forward", len(raw))
+        return 0
+
+    per_recip = int(cfg.get("rate_limit_per_recipient_per_hour") or 30)
+    global_lim = int(cfg.get("rate_limit_global_per_hour") or 100)
+    if not _rate_ok(f"r-{recipient}", per_recip) or not _rate_ok("global", global_lim):
+        logger.warning("Rate limit exceeded for %s; skip forward", recipient)
+        return 0
+
+    gmail_dest = (cfg.get("gmail_destination") or "").strip()
+    if not gmail_dest:
+        logger.error("gmail_destination missing in runtime config")
+        return 0
+
+    mail_obj = email.message_from_bytes(raw, policy=email.policy.default)
+    if not (mail_obj.get("From") and mail_obj.get("Date")):
+        logger.warning("Missing From/Date; skip")
+        return 0
+    if not _has_payload(mail_obj):
+        logger.warning("Empty payload; skip")
+        return 0
+
+    try:
+        ses.send_raw_email(
+            Source=recipient,
+            Destinations=[gmail_dest],
+            RawMessage={"Data": _build_forward_raw(mail_obj, recipient, gmail_dest)},
+        )
+        logger.info("Forwarded copy for allowlisted recipient via SES")
+    except ClientError:
+        logger.exception("SES SendRawEmail failed")
+        # Exit 0 so Exim does not bounce/defer the original local delivery.
+        return 0
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/directadmin/ses_gmail_forward.py
+++ b/scripts/directadmin/ses_gmail_forward.py
@@ -1,31 +1,28 @@
 #!/usr/bin/env python3
 """
-DirectAdmin / Exim pipe: copy allowlisted inbound mail to Gmail via SES.
+DirectAdmin pipe forwarder → Gmail via SES.
 
-MX stays on DirectAdmin (local delivery unchanged). Configure Exim/DA to also
-pipe a copy into this script (unseen). The script re-sends via SES as the
-local recipient (verified domain identity) with Reply-To = original From.
+Most seamless DA usage:
+  1. Keep the Email Account (Roundcube / local delivery).
+  2. E-Mail Accounts → Forwarders → create forwarder whose destination is:
+       | /usr/local/bin/ses-gmail-forward.py
+  3. Do NOT forward to a Gmail address through the SES smart host (554 unverified From).
 
-Usage (Exim pipe):
-  unseen pipe \"/usr/local/bin/ses-gmail-forward.py ${local_part}@${domain}\"
+MX stays on DirectAdmin. This script only sends an authenticated SES *copy*
+(From = allowlisted local address, Reply-To = original sender).
 
-Config: Secrets Manager tellerstech/ses-gmail-forward/runtime-config
-  {
-    \"gmail_destination\": \"your-gmail@example.com\",
-    \"recipients\": [\"user1@example.com\", \"user2@example.com\"],
-    \"rate_limit_per_recipient_per_hour\": 30,
-    \"rate_limit_global_per_hour\": 100,
-    \"max_message_bytes\": 10485760
-  }
+Recipient is taken from argv if present, otherwise from envelope/Delivered-To
+headers matched against the Secrets Manager allowlist.
 
-Requires: boto3, instance profile with ses:SendRawEmail + secretsmanager:GetSecretValue.
-Exit 0 on success / intentional skip so Exim does not defer local mail.
+Config secret: tellerstech/ses-gmail-forward/runtime-config
+Exit 0 always on skip/error so Exim does not bounce local mail.
 """
 
 from __future__ import annotations
 
 import email
 import email.policy
+import email.utils
 import json
 import logging
 import os
@@ -75,6 +72,37 @@ def _config() -> dict:
 
 def _allowlist(cfg: dict) -> set[str]:
     return {a.strip().lower() for a in (cfg.get("recipients") or []) if a}
+
+
+def _addresses_from_headers(mail_obj: email.message.Message) -> list[str]:
+    found: list[str] = []
+    for header in (
+        "Envelope-To",
+        "X-Envelope-To",
+        "Delivered-To",
+        "X-Original-To",
+        "X-Forwarded-To",
+        "To",
+        "Cc",
+    ):
+        for value in mail_obj.get_all(header) or []:
+            for _, addr in email.utils.getaddresses([value]):
+                if addr:
+                    found.append(addr.strip().lower())
+    return found
+
+
+def _resolve_recipient(argv: list[str], mail_obj: email.message.Message, allow: set[str]) -> str | None:
+    if len(argv) >= 2 and argv[1].strip():
+        candidate = argv[1].strip().lower()
+        if candidate in allow:
+            return candidate
+        logger.warning("argv recipient not allowlisted; trying headers")
+
+    for addr in _addresses_from_headers(mail_obj):
+        if addr in allow:
+            return addr
+    return None
 
 
 def _rate_ok(key: str, limit: int) -> bool:
@@ -140,14 +168,9 @@ def _build_forward_raw(original: email.message.Message, from_addr: str, gmail_de
 
 
 def main(argv: list[str]) -> int:
-    if len(argv) < 2:
-        logger.error("Usage: ses-gmail-forward.py local@domain < message.eml")
-        return 0
-
-    recipient = argv[1].strip().lower()
     raw = sys.stdin.buffer.read()
     if not raw:
-        logger.warning("Empty stdin for %s; skip", recipient)
+        logger.warning("Empty stdin; skip")
         return 0
 
     try:
@@ -156,8 +179,15 @@ def main(argv: list[str]) -> int:
         logger.exception("Failed to load runtime config")
         return 0
 
-    if recipient not in _allowlist(cfg):
-        logger.info("Recipient not allowlisted; skip")
+    allow = _allowlist(cfg)
+    if not allow:
+        logger.error("recipients allowlist empty in runtime config")
+        return 0
+
+    mail_obj = email.message_from_bytes(raw, policy=email.policy.default)
+    recipient = _resolve_recipient(argv, mail_obj, allow)
+    if not recipient:
+        logger.info("No allowlisted recipient in argv/headers; skip")
         return 0
 
     max_bytes = int(cfg.get("max_message_bytes") or 10 * 1024 * 1024)
@@ -176,7 +206,6 @@ def main(argv: list[str]) -> int:
         logger.error("gmail_destination missing in runtime config")
         return 0
 
-    mail_obj = email.message_from_bytes(raw, policy=email.policy.default)
     if not (mail_obj.get("From") and mail_obj.get("Date")):
         logger.warning("Missing From/Date; skip")
         return 0
@@ -190,10 +219,9 @@ def main(argv: list[str]) -> int:
             Destinations=[gmail_dest],
             RawMessage={"Data": _build_forward_raw(mail_obj, recipient, gmail_dest)},
         )
-        logger.info("Forwarded copy for allowlisted recipient via SES")
+        logger.info("Forwarded SES copy for %s", recipient)
     except ClientError:
         logger.exception("SES SendRawEmail failed")
-        # Exit 0 so Exim does not bounce/defer the original local delivery.
         return 0
 
     return 0


### PR DESCRIPTION
## Summary

- **MX stays on DirectAdmin.** Gmail gets a copy via an Exim/DA **unseen pipe** → `ses-gmail-forward.py` → SES `SendRawEmail` as the allowlisted local address (`Reply-To` = original sender).
- IAM: `WBAT_Main_Server` gains `ses:SendRawEmail` + read of `tellerstech/ses-gmail-forward/runtime-config`.
- Always-on Secrets Manager secret for allowlist / Gmail destination / rate limits (no addresses in git).
- SES **inbound receive** stack remains optional and documented as the wrong model when DA owns MX — leave `enable_inbound_forwarding = false`.

## Why

Pointing MX at SES made SES the inbound server. You want Postfix/Exim to keep handling inbound; only the Gmail copy should use SES (HTTPS API), which avoids the smart-host `554 Email address is not verified` failure.

## Setup (after apply)

1. Populate secret `tellerstech/ses-gmail-forward/runtime-config` (see `scripts/directadmin/ses_gmail_forward.md`).
2. Install `/usr/local/bin/ses-gmail-forward.py` on the mail server.
3. Wire Exim/DA **unseen** pipe (local delivery must still happen).
4. Remove broken DA→Gmail forwarders that used the SES smart host.
5. **Do not** change MX to `inbound-smtp.*.amazonaws.com`.

## Test plan

- [ ] AWS apply: secret + IAM policy present
- [ ] External mail → Roundcube still works (MX unchanged)
- [ ] Same message appears in Gmail via SES
- [ ] Non-allowlisted local addresses are not forwarded
- [ ] Pipe failure does not wipe local delivery


Made with [Cursor](https://cursor.com)