### PR TITLE
fix(mail): Exim pipe must not crash on log permissions

### DIFF
--- a/scripts/directadmin/ses_gmail_forward.md
+++ b/scripts/directadmin/ses_gmail_forward.md
@@ -62,7 +62,10 @@ install -m 755 scripts/directadmin/ses_gmail_forward.py \
   /usr/local/bin/ses-gmail-forward.py
 mkdir -p /var/lib/ses-gmail-forward
 touch /var/log/ses-gmail-forward.log
-chmod 750 /var/lib/ses-gmail-forward
+# Exim runs the pipe as the mail/DA user — must be group-writable.
+chgrp mail /var/log/ses-gmail-forward.log /var/lib/ses-gmail-forward
+chmod 665 /var/log/ses-gmail-forward.log
+chmod 775 /var/lib/ses-gmail-forward
 python3 -c 'import boto3; print(boto3.__version__)'
 ```
 

--- a/scripts/directadmin/ses_gmail_forward.py
+++ b/scripts/directadmin/ses_gmail_forward.py
@@ -43,15 +43,24 @@ SECRET_ID = os.environ.get(
 STATE_DIR = Path(os.environ.get("SES_GMAIL_FORWARD_STATE", "/var/lib/ses-gmail-forward"))
 AWS_REGION = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(levelname)s %(message)s",
-    handlers=[
-        logging.FileHandler(LOG_PATH),
-        logging.StreamHandler(sys.stderr),
-    ],
-)
-logger = logging.getLogger("ses-gmail-forward")
+
+def _setup_logging() -> logging.Logger:
+    """Prefer file log; never crash the pipe if the file is unwritable (Exim != root)."""
+    handlers: list[logging.Handler] = [logging.StreamHandler(sys.stderr)]
+    try:
+        handlers.insert(0, logging.FileHandler(LOG_PATH))
+    except OSError:
+        pass
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+        handlers=handlers,
+        force=True,
+    )
+    return logging.getLogger("ses-gmail-forward")
+
+
+logger = _setup_logging()
 
 secretsmanager = boto3.client("secretsmanager", region_name=AWS_REGION)
 ses = boto3.client("ses", region_name=AWS_REGION)
@@ -106,19 +115,24 @@ def _resolve_recipient(argv: list[str], mail_obj: email.message.Message, allow: 
 
 
 def _rate_ok(key: str, limit: int) -> bool:
-    STATE_DIR.mkdir(parents=True, exist_ok=True)
-    hour = datetime.now(timezone.utc).strftime("%Y%m%d%H")
-    path = STATE_DIR / f"rate-{key.replace('/', '_')}-{hour}.count"
     try:
-        count = int(path.read_text().strip() or "0")
-    except FileNotFoundError:
-        count = 0
+        STATE_DIR.mkdir(parents=True, exist_ok=True)
+        hour = datetime.now(timezone.utc).strftime("%Y%m%d%H")
+        path = STATE_DIR / f"rate-{key.replace('/', '_')}-{hour}.count"
+        try:
+            count = int(path.read_text().strip() or "0")
+        except FileNotFoundError:
+            count = 0
+        except OSError:
+            count = 0
+        if count >= limit:
+            return False
+        path.write_text(str(count + 1))
+        return True
     except OSError:
-        count = 0
-    if count >= limit:
-        return False
-    path.write_text(str(count + 1))
-    return True
+        # If state dir is not writable, do not block forwarding.
+        logger.warning("Rate-limit state unwritable; allowing send")
+        return True
 
 
 def _has_payload(msg: email.message.Message) -> bool:


### PR DESCRIPTION
## Summary
- Exim runs `| ses-gmail-forward.py` as a non-root user; opening `/var/log/ses-gmail-forward.log` caused `PermissionError` and a permanent local delivery failure.
- Logging now falls back to stderr if the file is unwritable; rate-limit state dir failures no longer block sends.
- Docs: set log/state group `mail` and group-writable modes on install.

## Test plan
- [ ] On server: fix perms (or deploy script), resend to brian@; no Mailer-Daemon bounce
- [ ] Roundcube + Gmail both receive when aliases are `user: user, |pipe`


Made with [Cursor](https://cursor.com)