### PR TITLE
fix(mail): Exim pipe stderr + virtual mailbox aliases

### DIFF
--- a/scripts/directadmin/ses_gmail_forward.md
+++ b/scripts/directadmin/ses_gmail_forward.md
@@ -13,9 +13,42 @@ For each mailbox that should also land in Gmail:
    - From: the local address (same as the mailbox)  
    - To: `| /usr/local/bin/ses-gmail-forward.py`  
      (leading pipe is required)
-3. Confirm DA still delivers to the mailbox (account + forwarder). If a forwarder
-   *replaces* delivery on your DA version, use a destination that keeps local
-   delivery as well (DA/Exim often stores `user: user, |/path/script` in aliases).
+3. Confirm DA still delivers to the mailbox. After saving, check aliases:
+
+```bash
+grep -E '^(brian|bteller):' /etc/virtual/tellerstech.com/aliases
+```
+
+Bare `brian` in the alias is rewritten to `brian@server.wbat.net` and fails.
+Use a backslash-qualified address so Exim delivers to the virtual mailbox
+without re-aliasing (and keep the pipe):
+
+```text
+brian: \brian@tellerstech.com, "|/usr/local/bin/ses-gmail-forward.py"
+bteller: \bteller@tellerstech.com, "|/usr/local/bin/ses-gmail-forward.py"
+```
+
+Apply with:
+
+```bash
+python3 <<'PY'
+from pathlib import Path
+path = Path("/etc/virtual/tellerstech.com/aliases")
+lines = []
+for line in path.read_text().splitlines():
+    if line.startswith("brian:"):
+        lines.append(r'brian: \brian@tellerstech.com, "|/usr/local/bin/ses-gmail-forward.py"')
+    elif line.startswith("bteller:"):
+        lines.append(r'bteller: \bteller@tellerstech.com, "|/usr/local/bin/ses-gmail-forward.py"')
+    else:
+        lines.append(line)
+path.write_text("\n".join(lines) + "\n")
+print(path.read_text())
+PY
+```
+
+**Important:** Do not edit these forwarders again in the DA UI without re-checking
+aliases — the UI may rewrite them to pipe-only or unqualified `brian`.
 
 That is the whole day-to-day UX. Allowlist / Gmail destination live in AWS
 Secrets Manager (not in git).

--- a/scripts/directadmin/ses_gmail_forward.py
+++ b/scripts/directadmin/ses_gmail_forward.py
@@ -45,12 +45,22 @@ AWS_REGION = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
 
 
 def _setup_logging() -> logging.Logger:
-    """Prefer file log; never crash the pipe if the file is unwritable (Exim != root)."""
-    handlers: list[logging.Handler] = [logging.StreamHandler(sys.stderr)]
+    """
+    Log to file when possible. Never write to stdout/stderr under Exim:
+    DA's pipe transport treats command output as a delivery failure even when
+    the process exits 0 (which produced the Mailer-Daemon bounce after SES
+    had already succeeded).
+    """
+    handlers: list[logging.Handler] = []
     try:
-        handlers.insert(0, logging.FileHandler(LOG_PATH))
+        handlers.append(logging.FileHandler(LOG_PATH))
     except OSError:
         pass
+    # Interactive/manual runs only — not when Exim pipes mail on stdin.
+    if sys.stderr.isatty():
+        handlers.append(logging.StreamHandler(sys.stderr))
+    if not handlers:
+        handlers.append(logging.NullHandler())
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s %(levelname)s %(message)s",


### PR DESCRIPTION
## Summary
- SES copy was succeeding, but Exim bounced because the pipe wrote INFO lines to stderr (DA treats pipe output as failure).
- Logging no longer uses stderr when not a TTY.
- Docs: aliases must use \`\\user@domain, |pipe\` — bare \`user\` becomes \`user@server.wbat.net\` and fails.

## Server fix (immediate)
Redeploy script from this branch/main after merge; rewrite aliases as documented; retest.


Made with [Cursor](https://cursor.com)