### PR TITLE
fix(mail): stop pipe dovecot-lda bounce; SES-only + health cron

### DIFF
--- a/scripts/directadmin/README.md
+++ b/scripts/directadmin/README.md
@@ -2,9 +2,9 @@
 
 ## Mail → Gmail via SES (canonical)
 
-Inbound MX stays on DirectAdmin. Pipe forwarder runs
-[`ses_gmail_forward.py`](./ses_gmail_forward.py) → **dovecot-lda** (Roundcube) +
-**SES** (Gmail copy).
+Inbound MX stays on DirectAdmin. Keep the **Email Account** (Exim → Roundcube).
+Pipe forwarder runs [`ses_gmail_forward.py`](./ses_gmail_forward.py) → **SES only**
+(Gmail copy). Do not use dovecot-lda in the pipe (fails as user `mail`).
 
 Full runbook: [`ses_gmail_forward.md`](./ses_gmail_forward.md).
 
@@ -43,6 +43,16 @@ install -m 700 scripts/directadmin/forwarder_delete_post.sh \
 # optional safety net:
 # echo '*/15 * * * * root /usr/local/bin/ensure-ses-gmail-aliases.sh' \
 #   >/etc/cron.d/ses-gmail-aliases
+
+# Health check (every 5m): self-heal aliases + flag recent forward ERROR
+install -m 755 scripts/directadmin/ses_gmail_forward_health.sh \
+  /usr/local/bin/ses-gmail-forward-health.sh
+install -m 600 scripts/directadmin/health.conf.example \
+  /etc/ses-gmail-forward/health.conf
+# edit HEALTH_ALERT_TO if you want local mail alerts
+echo '*/5 * * * * root /usr/local/bin/ses-gmail-forward-health.sh' \
+  >/etc/cron.d/ses-gmail-forward-health
+chmod 644 /etc/cron.d/ses-gmail-forward-health
 ```
 
 ## Backup hooks (server install)

--- a/scripts/directadmin/health.conf.example
+++ b/scripts/directadmin/health.conf.example
@@ -1,0 +1,5 @@
+# Optional health-check alert destination (local MTA).
+# Install as /etc/ses-gmail-forward/health.conf (mode 600).
+# Example:
+# HEALTH_ALERT_TO="user1@example.com"
+HEALTH_ALERT_TO=""

--- a/scripts/directadmin/ses_gmail_forward.md
+++ b/scripts/directadmin/ses_gmail_forward.md
@@ -5,10 +5,15 @@
 ```
 Internet
   → MX DirectAdmin / Exim
-  → virtual alias pipe: |/usr/local/bin/ses-gmail-forward.py
-       ├─ dovecot-lda  → Maildir / Roundcube
-       └─ SES SendRawEmail → personal Gmail (verified From + Reply-To original)
+       ├─ Email Account → virtual_mailbox (LMTP) → Maildir / Roundcube
+       └─ Forwarder pipe → ses-gmail-forward.py → SES → Gmail
+            (verified From + Reply-To original)
 ```
+
+**Critical:** Keep the **Email Account** in DA. Exim delivers Roundcube that way.
+The pipe runs as user `mail` and **must not** call `dovecot-lda` (Maildir is `0700`
+owned by the DA user → lda rc=75 → Exim bounce). The pipe only sends the SES copy
+and **always exits 0**.
 
 Outbound “Send mail as” from Gmail uses **SES SMTP** (`email-smtp.us-east-1.amazonaws.com:587`) with SES SMTP IAM credentials — separate from this inbound pipe.
 
@@ -84,9 +89,18 @@ touch /var/log/ses-gmail-forward.log
 chmod 666 /var/log/ses-gmail-forward.log
 chmod 777 /var/lib/ses-gmail-forward
 
-ls -la /usr/libexec/dovecot/dovecot-lda /usr/sbin/dovecot-lda 2>/dev/null
 python3 -c 'import boto3; print(boto3.__version__)'
 # Alma/Rocky: dnf install -y python3-boto3
+
+# Health check (self-heal aliases + alert on recent ERROR)
+curl -fsSL -o /usr/local/bin/ses-gmail-forward-health.sh \
+  https://raw.githubusercontent.com/wbat/wbat-terraform/main/scripts/directadmin/ses_gmail_forward_health.sh
+chmod 755 /usr/local/bin/ses-gmail-forward-health.sh
+install -m 600 scripts/directadmin/health.conf.example \
+  /etc/ses-gmail-forward/health.conf  # or curl the example; set HEALTH_ALERT_TO
+echo '*/5 * * * * root /usr/local/bin/ses-gmail-forward-health.sh' \
+  >/etc/cron.d/ses-gmail-forward-health
+chmod 644 /etc/cron.d/ses-gmail-forward-health
 ```
 
 ## Gmail (outbound)

--- a/scripts/directadmin/ses_gmail_forward.py
+++ b/scripts/directadmin/ses_gmail_forward.py
@@ -1,19 +1,25 @@
 #!/usr/bin/env python3
 """
-DirectAdmin pipe forwarder → local Maildir (Roundcube) + Gmail via SES.
+DirectAdmin pipe forwarder → Gmail via SES (Roundcube via Exim).
 
-Aliases must be pipe-only (DA cannot safely expand bare/local+backslash forms):
+Aliases must be pipe-only:
 
   localpart: "|/usr/local/bin/ses-gmail-forward.py"
 
-This script:
-  1) Delivers into the virtual mailbox via dovecot-lda (bypasses aliases)
-  2) Sends an authenticated SES copy to Gmail (verified From + Reply-To original)
+Architecture (DirectAdmin / Exim):
+  - Email Account exists → Exim virtual_mailbox (LMTP) delivers Roundcube copy
+  - Forwarder pipe → this script → SES SendRawEmail → Gmail
 
-Do NOT forward to a Gmail address through the SES smart host (554 unverified From).
+This script must NOT call dovecot-lda. The pipe runs as user `mail`, and DA
+Maildirs are mode 0700 owned by the DA user, so lda returns EX_TEMPFAIL (75)
+and Exim treats a non-zero pipe exit as a permanent bounce — even after the
+Roundcube copy already succeeded.
+
+Do NOT forward to Gmail through the SES smart host (554 unverified From).
 Do NOT change MX away from DirectAdmin.
 
 Config: Secrets Manager tellerstech/ses-gmail-forward/runtime-config
+Always exit 0 so Exim never bounces on SES/config failures (log instead).
 Never write to stdout/stderr under Exim (treated as pipe failure).
 """
 
@@ -25,7 +31,6 @@ import email.utils
 import json
 import logging
 import os
-import subprocess
 import sys
 import time
 from datetime import datetime, timezone
@@ -42,12 +47,6 @@ SECRET_ID = os.environ.get(
 )
 STATE_DIR = Path(os.environ.get("SES_GMAIL_FORWARD_STATE", "/var/lib/ses-gmail-forward"))
 AWS_REGION = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
-DOVECOT_LDA_CANDIDATES = (
-    "/usr/libexec/dovecot/dovecot-lda",
-    "/usr/sbin/dovecot-lda",
-    "/usr/libexec/dovecot/deliver",
-    "/usr/sbin/deliver",
-)
 
 
 def _setup_logging() -> logging.Logger:
@@ -130,7 +129,6 @@ def _resolve_recipient(argv: list[str], mail_obj: email.message.Message, allow: 
     for addr in candidates:
         if addr in allow:
             return addr
-    # Pipe-only aliases: still deliver locally if we can identify the mailbox.
     for addr in candidates:
         if "@" in addr:
             return addr
@@ -172,37 +170,6 @@ def _has_payload(msg: email.message.Message) -> bool:
     return bool(payload and payload.strip())
 
 
-def _find_dovecot_lda() -> str | None:
-    for path in DOVECOT_LDA_CANDIDATES:
-        if os.path.isfile(path) and os.access(path, os.X_OK):
-            return path
-    return None
-
-
-def _deliver_local(raw: bytes, recipient: str) -> bool:
-    lda = _find_dovecot_lda()
-    if not lda:
-        logger.error("dovecot-lda not found; cannot deliver to Roundcube")
-        return False
-    try:
-        proc = subprocess.run(
-            [lda, "-d", recipient],
-            input=raw,
-            capture_output=True,
-            timeout=60,
-            check=False,
-        )
-    except OSError:
-        logger.exception("Failed to exec dovecot-lda")
-        return False
-    if proc.returncode != 0:
-        err = (proc.stderr or b"").decode("utf-8", errors="replace")[:500]
-        logger.error("dovecot-lda failed rc=%s: %s", proc.returncode, err)
-        return False
-    logger.info("Delivered local mailbox copy for %s via dovecot-lda", recipient)
-    return True
-
-
 def _build_forward_raw(original: email.message.Message, from_addr: str, gmail_dest: str) -> bytes:
     msg = email.message_from_bytes(original.as_bytes(), policy=email.policy.SMTP)
     original_from = msg.get("From", "unknown")
@@ -240,22 +207,22 @@ def _send_ses(
     recipient: str,
     gmail_dest: str,
     cfg: dict,
-) -> None:
+) -> bool:
     max_bytes = int(cfg.get("max_message_bytes") or 10 * 1024 * 1024)
     if len(raw) > max_bytes:
         logger.warning("Message oversized (%s bytes); skip SES", len(raw))
-        return
+        return False
     per_recip = int(cfg.get("rate_limit_per_recipient_per_hour") or 30)
     global_lim = int(cfg.get("rate_limit_global_per_hour") or 100)
     if not _rate_ok(f"r-{recipient}", per_recip) or not _rate_ok("global", global_lim):
         logger.warning("Rate limit exceeded for %s; skip SES", recipient)
-        return
+        return False
     if not (mail_obj.get("From") and mail_obj.get("Date")):
         logger.warning("Missing From/Date; skip SES")
-        return
+        return False
     if not _has_payload(mail_obj):
         logger.warning("Empty payload; skip SES")
-        return
+        return False
     try:
         ses.send_raw_email(
             Source=recipient,
@@ -263,11 +230,14 @@ def _send_ses(
             RawMessage={"Data": _build_forward_raw(mail_obj, recipient, gmail_dest)},
         )
         logger.info("Forwarded SES copy for %s", recipient)
+        return True
     except ClientError:
         logger.exception("SES SendRawEmail failed")
+        return False
 
 
 def main(argv: list[str]) -> int:
+    # Always return 0: non-zero makes Exim bounce even when Roundcube already has mail.
     raw = sys.stdin.buffer.read()
     if not raw:
         logger.warning("Empty stdin; skip")
@@ -283,18 +253,14 @@ def main(argv: list[str]) -> int:
     mail_obj = email.message_from_bytes(raw, policy=email.policy.default)
     recipient = _resolve_recipient(argv, mail_obj, allow)
     if not recipient:
-        logger.error("Could not resolve recipient for local+SES delivery")
-        return 1
-
-    # Roundcube/Maildir first (aliases are pipe-only).
-    if not _deliver_local(raw, recipient):
-        return 1
+        logger.error("Could not resolve recipient for SES forward")
+        return 0
 
     gmail_dest = (cfg.get("gmail_destination") or "").strip()
     if recipient in allow and gmail_dest:
         _send_ses(mail_obj, raw, recipient, gmail_dest, cfg)
     elif recipient not in allow:
-        logger.info("Recipient not in SES allowlist; local-only delivery")
+        logger.info("Recipient not in SES allowlist; skip SES (Roundcube via Exim)")
     else:
         logger.error("gmail_destination missing in runtime config")
 

--- a/scripts/directadmin/ses_gmail_forward_health.sh
+++ b/scripts/directadmin/ses_gmail_forward_health.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+# Health check for SES Gmail pipe path. Cron every 5 minutes.
+# Alerts by logging + optional mail if HEALTH_ALERT_TO is set in
+# /etc/ses-gmail-forward/health.conf
+#
+# Install:
+#   install -m 755 ses_gmail_forward_health.sh /usr/local/bin/ses-gmail-forward-health.sh
+#   echo '*/5 * * * * root /usr/local/bin/ses-gmail-forward-health.sh' \
+#     >/etc/cron.d/ses-gmail-forward-health
+
+set -euo pipefail
+
+CONF="${SES_GMAIL_HEALTH_CONF:-/etc/ses-gmail-forward/health.conf}"
+LOG="${SES_GMAIL_HEALTH_LOG:-/var/log/ses-gmail-forward-health.log}"
+FORWARD_LOG="${SES_GMAIL_FORWARD_LOG:-/var/log/ses-gmail-forward.log}"
+SCRIPT="${SES_GMAIL_FORWARD_SCRIPT:-/usr/local/bin/ses-gmail-forward.py}"
+ALIASES_ENSURE="${ENSURE_SES_GMAIL_ALIASES:-/usr/local/bin/ensure-ses-gmail-aliases.sh}"
+STATE_DIR="${SES_GMAIL_HEALTH_STATE:-/var/lib/ses-gmail-forward}"
+ALERT_STAMP="${STATE_DIR}/health-alert.stamp"
+WINDOW_MINUTES="${SES_GMAIL_HEALTH_WINDOW_MINUTES:-15}"
+
+HEALTH_ALERT_TO=""
+if [[ -f "$CONF" ]]; then
+  # shellcheck disable=SC1090
+  source "$CONF"
+fi
+
+log() {
+  echo "$(date -Iseconds) $*" >>"$LOG" 2>/dev/null || true
+}
+
+fail=0
+reasons=()
+
+# 1) Script present + executable
+if [[ ! -x "$SCRIPT" ]]; then
+  fail=1
+  reasons+=("missing_or_not_executable:$SCRIPT")
+fi
+
+# 2) python + boto3
+if ! python3 -c 'import boto3' >/dev/null 2>&1; then
+  fail=1
+  reasons+=("boto3_missing")
+fi
+
+# 3) Enforce aliases (self-heal)
+if [[ -x "$ALIASES_ENSURE" ]]; then
+  "$ALIASES_ENSURE" >/dev/null 2>&1 || {
+    fail=1
+    reasons+=("alias_ensure_failed")
+  }
+fi
+
+# 4) Recent ERROR lines in forward log (pipe failures / SES)
+if [[ -f "$FORWARD_LOG" ]]; then
+  # GNU find -mmin on the log isn't enough; scan recent ERROR lines by timestamp prefix.
+  cutoff="$(date -d "-${WINDOW_MINUTES} minutes" '+%Y-%m-%d %H:%M:%S' 2>/dev/null || date -v-"${WINDOW_MINUTES}"M '+%Y-%m-%d %H:%M:%S')"
+  # shellcheck disable=SC2016
+  recent_errors="$(awk -v c="$cutoff" '
+    $0 ~ / ERROR / {
+      # Obsolete path: lda under pipe as user mail (fixed; ignore historical noise)
+      if ($0 ~ /dovecot-lda failed/) next
+      ts = substr($0, 1, 19)
+      if (ts >= c) print
+    }
+  ' "$FORWARD_LOG" | tail -20)"
+  if [[ -n "$recent_errors" ]]; then
+    fail=1
+    reasons+=("recent_forward_errors")
+    log "RECENT_ERRORS:"$'\n'"$recent_errors"
+  fi
+fi
+
+# 5) Managed aliases still pipe-only (quick grep if config exists)
+MANAGED="${SES_GMAIL_ALIASES_CONF:-/etc/ses-gmail-forward/managed-aliases.conf}"
+if [[ -f "$MANAGED" ]]; then
+  while read -r domain parts; do
+    [[ -z "${domain:-}" || "$domain" =~ ^# ]] && continue
+    aliases="/etc/virtual/${domain}/aliases"
+    [[ -f "$aliases" ]] || continue
+    IFS=',' read -r -a lps <<<"${parts// /}"
+    for lp in "${lps[@]}"; do
+      [[ -z "$lp" ]] && continue
+      line="$(grep -E "^${lp}:" "$aliases" 2>/dev/null || true)"
+      if [[ "$line" != *'|/usr/local/bin/ses-gmail-forward.py'* ]]; then
+        fail=1
+        reasons+=("bad_alias:${domain}:${lp}")
+      fi
+    done
+  done < <(grep -vE '^\s*(#|$)' "$MANAGED" || true)
+fi
+
+mkdir -p "$STATE_DIR"
+
+if [[ "$fail" -eq 0 ]]; then
+  log "OK"
+  rm -f "$ALERT_STAMP"
+  exit 0
+fi
+
+msg="ses-gmail-forward HEALTH FAIL: ${reasons[*]}"
+log "$msg"
+
+# Rate-limit alerts to once per hour
+now_epoch="$(date +%s)"
+if [[ -f "$ALERT_STAMP" ]]; then
+  last="$(cat "$ALERT_STAMP" 2>/dev/null || echo 0)"
+  if (( now_epoch - last < 3600 )); then
+    exit 1
+  fi
+fi
+echo "$now_epoch" >"$ALERT_STAMP"
+
+if [[ -n "$HEALTH_ALERT_TO" ]]; then
+  printf '%s\n' "$msg" "See $FORWARD_LOG and $LOG" \
+    | mail -s "ses-gmail-forward health FAIL on $(hostname -s)" "$HEALTH_ALERT_TO" 2>/dev/null || true
+fi
+
+exit 1


### PR DESCRIPTION
## Summary

- **Root cause:** Exim already delivers Roundcube via `virtual_mailbox` (LMTP). The forwarder pipe runs as user `mail`, but DA Maildirs are `0700` owned by the DA user → `dovecot-lda` returns **rc=75** → script exited 1 → Exim permanent bounce **and SES never ran**.
- **Fix:** Pipe is **SES-only**, always exits **0**. Roundcube stays on Exim’s Email Account path. Keep Email Accounts in DA.
- **Resilience:** `ses_gmail_forward_health.sh` every 5 minutes — re-runs alias ensure, checks script/boto3/aliases, alerts on recent forward `ERROR` (ignores obsolete lda noise). Optional `HEALTH_ALERT_TO` in `/etc/ses-gmail-forward/health.conf`.

## Already deployed

Hotfixed on `server.wbat.net` (script + health cron). This PR matches what’s live.

## Test plan

- [x] `su mail -c '… | ses-gmail-forward.py'` → exit 0 + `Forwarded SES copy` in log
- [ ] External mail to allowlisted address → Roundcube + Gmail, no Mailer-Daemon bounce
- [ ] Health cron logs `OK`


Made with [Cursor](https://cursor.com)