### PR TITLE
feat(cloudfront): branded S3 custom error pages for www

### DIFF
--- a/aws/docs/cloudfront-tellerstech-502-troubleshooting.md
+++ b/aws/docs/cloudfront-tellerstech-502-troubleshooting.md
@@ -8,9 +8,18 @@ When the site returns **502 Bad Gateway** from CloudFront, the failure is betwee
 - **Origin domain**: `origin.tellerstech.com` (variable `origin_fqdn`, default in `cloudfront/variables.tf`). *Not* the server IP.
 - **Origin protocol**: HTTPS only (port 443), TLS 1.2.
 - **Custom header**: `X-CloudFront-Secret` = `var.cloudfront_origin_secret` (TFC/credentials).
+- **Custom error pages**: private S3 bucket + OAC (`error-pages.tf`); `custom_error_response` maps viewer-facing 403/404 → branded HTML and 500/502/503/504 → `/errors/503.html`, keeping the **real status code**.
 - **DNS**: `origin.tellerstech.com` is described as "managed in BIND" (outside this repo). `www.tellerstech.com` CNAMEs to the CloudFront domain.
 
 CloudFront therefore connects to **https://origin.tellerstech.com** and sends the secret header. The server must respond successfully to that request.
+
+## Branded error pages (www)
+
+When WordPress returns 403/404/5xx, or CloudFront cannot reach the origin (502/504), viewers of **www.tellerstech.com** get static HTML from S3 (`aws/global/cloudfront/errors/`), not the raw nginx/WP body. Status codes are unchanged (no fake 200).
+
+- Direct check: `curl -sI https://www.tellerstech.com/errors/503.html` → **200** from the S3 origin behavior.
+- Missing path: `curl -sI https://www.tellerstech.com/this-path-does-not-exist-tt/` → **404** with branded page.
+- Direct `origin.tellerstech.com` bypasses CloudFront and does **not** get these pages.
 
 ## Server-side companions (not in this repo)
 
@@ -38,8 +47,8 @@ Ops docs and scripts live in **TellersTechOrg/tellerstech-website**:
 
 3. **Nginx origin gate (403, not 502)**
    - Anonymous `https://origin.tellerstech.com/` without `X-CloudFront-Secret` returns **403** by design (scraper protection). That is **not** a CloudFront 502.
-   - Secret mismatch (CF header ≠ nginx cust_nginx ≠ wp-config) also yields origin **403**. This distribution has no `custom_error_response` that rewrites origin 403 → 502, so CloudFront typically **passes through 403**. Debug secret rotation when you observe **403** (viewer or origin curl), not when debugging **502**.
-   - Reserve **502** for connection/TLS/DNS/origin-unreachable failures (checklist items 1–2 and 4).
+   - Secret mismatch (CF header ≠ nginx cust_nginx ≠ wp-config) also yields origin **403**. On **www**, CloudFront keeps status **403** and may serve the branded `/errors/403.html` body via `custom_error_response` — it does **not** turn 403 into 502. Debug secret rotation when you observe **403**, not when debugging **502**.
+   - Reserve **502** for connection/TLS/DNS/origin-unreachable failures (checklist items 1–2 and 4). A viewer-facing **502** may show the branded “Temporarily unavailable” page while the status remains 502.
    - When debugging **403** after a rotation: align all four secret copies; reinstall gate with `install-cloudfront-origin-gate.sh`.
    - **DirectAdmin**: use parent `tellerstech.com.cust_nginx` (host-conditional). `origin.tellerstech.com.cust_nginx` is ignored (subdomain, not a DA domain). After `rewrite nginx`, immediately re-run the loopback fixer.
 
@@ -72,6 +81,7 @@ Ops docs and scripts live in **TellersTechOrg/tellerstech-website**:
 | DNS for origin    | BIND / external DNS → must point to origin server             |
 | SSL for origin    | Server: name/SAN covering `origin.tellerstech.com`; loopback listens required (**502** if wrong) |
 | Nginx vhost       | DA + `fix-nginx-loopback-listeners.sh`; parent cust_nginx gate |
+| Error HTML (www)  | Terraform: S3 + OAC + `custom_error_response` → `/errors/*.html` |
 
 For **502**, fix the first failing DNS/TLS/reachability check. For **403**, align the secret gate.
 

--- a/aws/global/cloudfront/error-pages.tf
+++ b/aws/global/cloudfront/error-pages.tf
@@ -1,0 +1,94 @@
+# Private S3 origin for CloudFront custom error pages (www.tellerstech.com).
+# HTML lives under errors/; objects are keyed as errors/*.html so CF can serve
+# /errors/404.html etc. via OAC when WordPress is down or returns 4xx/5xx.
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_s3_bucket" "cf_errors" {
+  bucket = "wbat-tellerstech-cf-errors-${data.aws_caller_identity.current.account_id}"
+
+  tags = merge(
+    var.core_tags,
+    {
+      "Name"     = "tellerstech-cloudfront-error-pages"
+      "scm:file" = "aws/global/cloudfront/error-pages.tf"
+    },
+  )
+}
+
+resource "aws_s3_bucket_versioning" "cf_errors" {
+  bucket = aws_s3_bucket.cf_errors.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "cf_errors" {
+  bucket = aws_s3_bucket.cf_errors.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "cf_errors" {
+  bucket = aws_s3_bucket.cf_errors.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_cloudfront_origin_access_control" "cf_errors" {
+  name                              = "tellerstech-cf-errors-oac"
+  description                       = "OAC for www.tellerstech.com custom error pages"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+resource "aws_s3_bucket_policy" "cf_errors" {
+  bucket = aws_s3_bucket.cf_errors.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowCloudFrontServicePrincipalRead"
+        Effect = "Allow"
+        Principal = {
+          Service = "cloudfront.amazonaws.com"
+        }
+        Action   = "s3:GetObject"
+        Resource = "${aws_s3_bucket.cf_errors.arn}/*"
+        Condition = {
+          StringEquals = {
+            "AWS:SourceArn" = aws_cloudfront_distribution.tellerstech_website.arn
+          }
+        }
+      }
+    ]
+  })
+}
+
+locals {
+  cf_error_pages = {
+    "errors/403.html" = "${path.module}/errors/403.html"
+    "errors/404.html" = "${path.module}/errors/404.html"
+    "errors/503.html" = "${path.module}/errors/503.html"
+  }
+}
+
+resource "aws_s3_object" "cf_errors" {
+  for_each = local.cf_error_pages
+
+  bucket       = aws_s3_bucket.cf_errors.id
+  key          = each.key
+  source       = each.value
+  etag         = filemd5(each.value)
+  content_type = "text/html; charset=utf-8"
+}

--- a/aws/global/cloudfront/errors/403.html
+++ b/aws/global/cloudfront/errors/403.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex">
+  <title>Access denied — Teller's Tech</title>
+  <style>
+    :root {
+      --deep: #050d1a;
+      --tt-mid: #235668;
+      --cyan: #649aa9;
+      --blue: #4c98b0;
+      --text: #e2e8f0;
+      --dim: #a1afc4;
+      --lightest: #7dbeca;
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 2rem 1.25rem;
+      font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      background:
+        radial-gradient(ellipse 80% 50% at 50% -20%, rgba(100, 154, 169, 0.22), transparent),
+        linear-gradient(165deg, var(--deep) 0%, #0a1a28 45%, #0d2433 100%);
+      color: var(--text);
+      text-align: center;
+    }
+    .brand {
+      font-size: 0.8rem;
+      font-weight: 700;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--lightest);
+      margin-bottom: 1.5rem;
+    }
+    .code {
+      font-size: clamp(3.5rem, 12vw, 5.5rem);
+      font-weight: 800;
+      line-height: 1;
+      letter-spacing: -0.03em;
+      background: linear-gradient(135deg, var(--lightest), var(--cyan), var(--blue));
+      -webkit-background-clip: text;
+      background-clip: text;
+      -webkit-text-fill-color: transparent;
+      margin-bottom: 0.75rem;
+    }
+    h1 {
+      font-size: clamp(1.35rem, 3.5vw, 1.75rem);
+      font-weight: 700;
+      margin-bottom: 0.75rem;
+      letter-spacing: -0.01em;
+    }
+    p {
+      color: var(--dim);
+      max-width: 28rem;
+      line-height: 1.55;
+      margin: 0 auto 1.75rem;
+      font-size: 1rem;
+    }
+    .cta {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.9rem 1.6rem;
+      border-radius: 12px;
+      font-weight: 700;
+      font-size: 1rem;
+      text-decoration: none;
+      color: #fff;
+      background: linear-gradient(135deg, var(--cyan), var(--blue));
+      box-shadow: 0 4px 20px rgba(100, 154, 169, 0.3);
+      margin-bottom: 2rem;
+    }
+    .cta:hover { filter: brightness(1.08); }
+    .cta:focus-visible { outline: 2px solid #fff; outline-offset: 3px; }
+    nav {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem 1.25rem;
+      justify-content: center;
+      font-size: 0.875rem;
+    }
+    nav a {
+      color: var(--cyan);
+      text-decoration: none;
+    }
+    nav a:hover { color: var(--lightest); text-decoration: underline; }
+    nav a:focus-visible { outline: 2px solid var(--cyan); outline-offset: 3px; border-radius: 2px; }
+  </style>
+</head>
+<body>
+  <p class="brand">Teller's Tech</p>
+  <p class="code" aria-hidden="true">403</p>
+  <h1>Access denied.</h1>
+  <p>You don't have permission to view this resource. If you followed a link here, try the home page instead.</p>
+  <a class="cta" href="/">Back to home</a>
+  <nav aria-label="Popular destinations">
+    <a href="/ship-it-weekly-podcast/">Ship It Weekly</a>
+    <a href="/on-call-brief-news/">On Call Brief</a>
+    <a href="/labs/code-duck/">Code Duck</a>
+    <a href="/contact-us/">Contact</a>
+  </nav>
+</body>
+</html>

--- a/aws/global/cloudfront/errors/404.html
+++ b/aws/global/cloudfront/errors/404.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex">
+  <title>Page not found — Teller's Tech</title>
+  <style>
+    :root {
+      --deep: #050d1a;
+      --tt-mid: #235668;
+      --cyan: #649aa9;
+      --blue: #4c98b0;
+      --text: #e2e8f0;
+      --dim: #a1afc4;
+      --lightest: #7dbeca;
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 2rem 1.25rem;
+      font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      background:
+        radial-gradient(ellipse 80% 50% at 50% -20%, rgba(100, 154, 169, 0.22), transparent),
+        linear-gradient(165deg, var(--deep) 0%, #0a1a28 45%, #0d2433 100%);
+      color: var(--text);
+      text-align: center;
+    }
+    .brand {
+      font-size: 0.8rem;
+      font-weight: 700;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--lightest);
+      margin-bottom: 1.5rem;
+    }
+    .code {
+      font-size: clamp(3.5rem, 12vw, 5.5rem);
+      font-weight: 800;
+      line-height: 1;
+      letter-spacing: -0.03em;
+      background: linear-gradient(135deg, var(--lightest), var(--cyan), var(--blue));
+      -webkit-background-clip: text;
+      background-clip: text;
+      -webkit-text-fill-color: transparent;
+      margin-bottom: 0.75rem;
+    }
+    h1 {
+      font-size: clamp(1.35rem, 3.5vw, 1.75rem);
+      font-weight: 700;
+      margin-bottom: 0.75rem;
+      letter-spacing: -0.01em;
+    }
+    p {
+      color: var(--dim);
+      max-width: 28rem;
+      line-height: 1.55;
+      margin: 0 auto 1.75rem;
+      font-size: 1rem;
+    }
+    .cta {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.9rem 1.6rem;
+      border-radius: 12px;
+      font-weight: 700;
+      font-size: 1rem;
+      text-decoration: none;
+      color: #fff;
+      background: linear-gradient(135deg, var(--cyan), var(--blue));
+      box-shadow: 0 4px 20px rgba(100, 154, 169, 0.3);
+      margin-bottom: 2rem;
+    }
+    .cta:hover { filter: brightness(1.08); }
+    .cta:focus-visible { outline: 2px solid #fff; outline-offset: 3px; }
+    nav {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem 1.25rem;
+      justify-content: center;
+      font-size: 0.875rem;
+    }
+    nav a {
+      color: var(--cyan);
+      text-decoration: none;
+    }
+    nav a:hover { color: var(--lightest); text-decoration: underline; }
+    nav a:focus-visible { outline: 2px solid var(--cyan); outline-offset: 3px; border-radius: 2px; }
+  </style>
+</head>
+<body>
+  <p class="brand">Teller's Tech</p>
+  <p class="code" aria-hidden="true">404</p>
+  <h1>That page wandered off.</h1>
+  <p>The URL may be mistyped, moved, or retired. Head home or try one of the links below.</p>
+  <a class="cta" href="/">Back to home</a>
+  <nav aria-label="Popular destinations">
+    <a href="/ship-it-weekly-podcast/">Ship It Weekly</a>
+    <a href="/on-call-brief-news/">On Call Brief</a>
+    <a href="/labs/code-duck/">Code Duck</a>
+    <a href="/contact-us/">Contact</a>
+  </nav>
+</body>
+</html>

--- a/aws/global/cloudfront/errors/503.html
+++ b/aws/global/cloudfront/errors/503.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex">
+  <title>Temporarily unavailable — Teller's Tech</title>
+  <style>
+    :root {
+      --deep: #050d1a;
+      --tt-mid: #235668;
+      --cyan: #649aa9;
+      --blue: #4c98b0;
+      --text: #e2e8f0;
+      --dim: #a1afc4;
+      --lightest: #7dbeca;
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 2rem 1.25rem;
+      font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      background:
+        radial-gradient(ellipse 80% 50% at 50% -20%, rgba(100, 154, 169, 0.22), transparent),
+        linear-gradient(165deg, var(--deep) 0%, #0a1a28 45%, #0d2433 100%);
+      color: var(--text);
+      text-align: center;
+    }
+    .brand {
+      font-size: 0.8rem;
+      font-weight: 700;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--lightest);
+      margin-bottom: 1.5rem;
+    }
+    .code {
+      font-size: clamp(3.5rem, 12vw, 5.5rem);
+      font-weight: 800;
+      line-height: 1;
+      letter-spacing: -0.03em;
+      background: linear-gradient(135deg, var(--lightest), var(--cyan), var(--blue));
+      -webkit-background-clip: text;
+      background-clip: text;
+      -webkit-text-fill-color: transparent;
+      margin-bottom: 0.75rem;
+    }
+    h1 {
+      font-size: clamp(1.35rem, 3.5vw, 1.75rem);
+      font-weight: 700;
+      margin-bottom: 0.75rem;
+      letter-spacing: -0.01em;
+    }
+    p {
+      color: var(--dim);
+      max-width: 28rem;
+      line-height: 1.55;
+      margin: 0 auto 1.75rem;
+      font-size: 1rem;
+    }
+    .cta {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.9rem 1.6rem;
+      border-radius: 12px;
+      font-weight: 700;
+      font-size: 1rem;
+      text-decoration: none;
+      color: #fff;
+      background: linear-gradient(135deg, var(--cyan), var(--blue));
+      box-shadow: 0 4px 20px rgba(100, 154, 169, 0.3);
+      margin-bottom: 2rem;
+    }
+    .cta:hover { filter: brightness(1.08); }
+    .cta:focus-visible { outline: 2px solid #fff; outline-offset: 3px; }
+    nav {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem 1.25rem;
+      justify-content: center;
+      font-size: 0.875rem;
+    }
+    nav a {
+      color: var(--cyan);
+      text-decoration: none;
+    }
+    nav a:hover { color: var(--lightest); text-decoration: underline; }
+    nav a:focus-visible { outline: 2px solid var(--cyan); outline-offset: 3px; border-radius: 2px; }
+  </style>
+</head>
+<body>
+  <p class="brand">Teller's Tech</p>
+  <p class="code" aria-hidden="true">503</p>
+  <h1>Temporarily unavailable.</h1>
+  <p>We're having trouble reaching the site right now. Please try again in a moment.</p>
+  <a class="cta" href="/">Try home again</a>
+  <nav aria-label="Popular destinations">
+    <a href="/ship-it-weekly-podcast/">Ship It Weekly</a>
+    <a href="/on-call-brief-news/">On Call Brief</a>
+    <a href="/labs/code-duck/">Code Duck</a>
+    <a href="/contact-us/">Contact</a>
+  </nav>
+</body>
+</html>

--- a/aws/global/cloudfront/outputs.tf
+++ b/aws/global/cloudfront/outputs.tf
@@ -12,3 +12,8 @@ output "distribution_arn" {
   value       = aws_cloudfront_distribution.tellerstech_website.arn
   description = "CloudFront distribution ARN"
 }
+
+output "error_pages_bucket_id" {
+  value       = aws_s3_bucket.cf_errors.id
+  description = "Private S3 bucket for CloudFront custom error HTML"
+}

--- a/aws/global/cloudfront/tellerstech-website.tf
+++ b/aws/global/cloudfront/tellerstech-website.tf
@@ -206,6 +206,14 @@ resource "aws_cloudfront_distribution" "tellerstech_website" {
     }
   }
 
+  # Static branded error pages (private S3 + OAC). Used by custom_error_response
+  # and by direct GETs to /errors/*.html when debugging.
+  origin {
+    domain_name              = aws_s3_bucket.cf_errors.bucket_regional_domain_name
+    origin_id                = "error-pages-s3"
+    origin_access_control_id = aws_cloudfront_origin_access_control.cf_errors.id
+  }
+
   # Default behavior - WordPress pages with session cookie handling
   default_cache_behavior {
     allowed_methods          = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
@@ -215,6 +223,17 @@ resource "aws_cloudfront_distribution" "tellerstech_website" {
     compress                 = true
     cache_policy_id          = aws_cloudfront_cache_policy.wordpress.id
     origin_request_policy_id = aws_cloudfront_origin_request_policy.wordpress.id
+  }
+
+  # Preferential: serve error HTML from S3 (must be first ordered behavior).
+  ordered_cache_behavior {
+    path_pattern           = "/errors/*"
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = "error-pages-s3"
+    viewer_protocol_policy = "redirect-to-https"
+    compress               = true
+    cache_policy_id        = "658327ea-f89d-4fab-a63d-7e88639e58f6" # AWS Managed CachingOptimized
   }
 
   # Ship It Weekly hub page - capped at 12 hours (Podcast-CachePolicy) so the
@@ -387,6 +406,50 @@ resource "aws_cloudfront_distribution" "tellerstech_website" {
     compress                   = true
     cache_policy_id            = aws_cloudfront_cache_policy.static_assets.id
     response_headers_policy_id = aws_cloudfront_response_headers_policy.static_assets.id
+  }
+
+  # Branded static pages from the error-pages-s3 origin. response_code matches
+  # error_code (no fake 200). 5xx cache briefly; 4xx a bit longer.
+  custom_error_response {
+    error_code            = 403
+    response_code         = 403
+    response_page_path    = "/errors/403.html"
+    error_caching_min_ttl = 120
+  }
+
+  custom_error_response {
+    error_code            = 404
+    response_code         = 404
+    response_page_path    = "/errors/404.html"
+    error_caching_min_ttl = 120
+  }
+
+  custom_error_response {
+    error_code            = 500
+    response_code         = 500
+    response_page_path    = "/errors/503.html"
+    error_caching_min_ttl = 30
+  }
+
+  custom_error_response {
+    error_code            = 502
+    response_code         = 502
+    response_page_path    = "/errors/503.html"
+    error_caching_min_ttl = 30
+  }
+
+  custom_error_response {
+    error_code            = 503
+    response_code         = 503
+    response_page_path    = "/errors/503.html"
+    error_caching_min_ttl = 30
+  }
+
+  custom_error_response {
+    error_code            = 504
+    response_code         = 504
+    response_page_path    = "/errors/503.html"
+    error_caching_min_ttl = 30
   }
 
   restrictions {


### PR DESCRIPTION
## Summary
- Add site-wide static `403` / `404` / `503` HTML under `aws/global/cloudfront/errors/` (TT brand, no external font deps).
- Provision a private S3 bucket + OAC + object uploads (`error-pages.tf`) and wire a second CloudFront origin with `/errors/*` behavior plus `custom_error_response` mapping (real status codes kept; 5xx → 503 page).
- Document the branded error path in the CloudFront 502 troubleshooting runbook.

## Test plan
- [ ] TFC plan for global/cloudfront shows new bucket, OAC, objects, distribution origin/behavior/`custom_error_response` only
- [ ] After apply: `curl -sI https://www.tellerstech.com/errors/503.html` → 200
- [ ] After apply: missing path on www → branded body, status still 404
- [ ] Confirm origin gate on `origin.tellerstech.com` still returns raw 403 (bypasses CF error pages)


Made with [Cursor](https://cursor.com)