### PR TITLE
fix(cloudfront): /wp-admin no-slash must not land on origin

### DIFF
--- a/aws/docs/cloudfront-tellerstech-502-troubleshooting.md
+++ b/aws/docs/cloudfront-tellerstech-502-troubleshooting.md
@@ -13,6 +13,12 @@ When the site returns **502 Bad Gateway** from CloudFront, the failure is betwee
 
 CloudFront therefore connects to **https://origin.tellerstech.com** and sends the secret header. The server must respond successfully to that request.
 
+## wp-admin redirects to origin (403)
+
+Exact path `/wp-admin` (no trailing slash) is **not** matched by `/wp-admin/*`, so it used the default cache behavior. Nginx’s trailing-slash 301 used `Host: origin.tellerstech.com`, CloudFront cached `Location: https://origin.tellerstech.com/wp-admin/`, and browsers then hit the gated origin → **403**.
+
+Edge mitigations live in `aws/global/cloudfront/functions.tf` + exact `/wp-admin` behavior in `tellerstech-website.tf`. Workaround: use `https://www.tellerstech.com/wp-admin/`.
+
 ## Branded error pages (www)
 
 When CloudFront cannot reach the origin or the origin returns **5xx** (500/502/503/504), viewers of **www.tellerstech.com** get static HTML from S3 (`/errors/503.html`). Status codes are unchanged (no fake 200).

--- a/aws/global/cloudfront/functions.tf
+++ b/aws/global/cloudfront/functions.tf
@@ -1,0 +1,72 @@
+# CloudFront Functions for www.tellerstech.com
+#
+# Origin Host is origin.tellerstech.com (required; forwarding viewer Host causes
+# 502s). Nginx absolute redirects therefore use that host unless we rewrite them
+# at the edge. wp-config.php already fixes PHP redirects when the shared secret
+# matches; these functions cover nginx-level redirects (e.g. trailing slash).
+
+resource "aws_cloudfront_function" "wp_admin_trailing_slash" {
+  name    = "tellerstech-wp-admin-trailing-slash"
+  runtime = "cloudfront-js-2.0"
+  comment = "Redirect /wp-admin → /wp-admin/ on www before nginx Host-based 301"
+  publish = true
+  code    = <<-EOF
+function handler(event) {
+  var request = event.request;
+  if (request.uri === '/wp-admin') {
+    var location = 'https://www.tellerstech.com/wp-admin/';
+    var parts = [];
+    Object.keys(request.querystring).forEach(function (key) {
+      var q = request.querystring[key];
+      if (q.multiValue) {
+        q.multiValue.forEach(function (item) {
+          parts.push(key + '=' + item.value);
+        });
+      } else if (q.value) {
+        parts.push(key + '=' + q.value);
+      } else {
+        parts.push(key);
+      }
+    });
+    if (parts.length > 0) {
+      location += '?' + parts.join('&');
+    }
+    return {
+      statusCode: 301,
+      statusDescription: 'Moved Permanently',
+      headers: {
+        location: { value: location }
+      }
+    };
+  }
+  return request;
+}
+EOF
+}
+
+resource "aws_cloudfront_function" "rewrite_origin_location" {
+  name    = "tellerstech-rewrite-origin-location"
+  runtime = "cloudfront-js-2.0"
+  comment = "Rewrite Location: origin.tellerstech.com → www.tellerstech.com"
+  publish = true
+  code    = <<-EOF
+function handler(event) {
+  var response = event.response;
+  var headers = response.headers;
+  if (!headers.location) {
+    return response;
+  }
+  var loc = headers.location.value;
+  if (loc.indexOf('://origin.tellerstech.com') !== -1) {
+    headers.location = {
+      value: loc.split('://origin.tellerstech.com').join('://www.tellerstech.com')
+    };
+  } else if (loc.indexOf('://www.origin.tellerstech.com') !== -1) {
+    headers.location = {
+      value: loc.split('://www.origin.tellerstech.com').join('://www.tellerstech.com')
+    };
+  }
+  return response;
+}
+EOF
+}

--- a/aws/global/cloudfront/tellerstech-website.tf
+++ b/aws/global/cloudfront/tellerstech-website.tf
@@ -223,6 +223,17 @@ resource "aws_cloudfront_distribution" "tellerstech_website" {
     compress                 = true
     cache_policy_id          = aws_cloudfront_cache_policy.wordpress.id
     origin_request_policy_id = aws_cloudfront_origin_request_policy.wordpress.id
+
+    # /wp-admin (no trailing slash) falls through here — not matched by /wp-admin/*.
+    # Edge functions stop nginx Host-based redirects to origin.tellerstech.com.
+    function_association {
+      event_type   = "viewer-request"
+      function_arn = aws_cloudfront_function.wp_admin_trailing_slash.arn
+    }
+    function_association {
+      event_type   = "viewer-response"
+      function_arn = aws_cloudfront_function.rewrite_origin_location.arn
+    }
   }
 
   # Preferential: serve error HTML from S3 (must be first ordered behavior).
@@ -276,6 +287,29 @@ resource "aws_cloudfront_distribution" "tellerstech_website" {
     origin_request_policy_id = aws_cloudfront_origin_request_policy.wordpress.id
   }
 
+  # Exact /wp-admin (no trailing slash). /wp-admin/* does NOT match this path, so
+  # without this block it used the default cache policy and CloudFront cached
+  # nginx's 301 to https://origin.tellerstech.com/wp-admin/ → viewer 403.
+  ordered_cache_behavior {
+    path_pattern             = "/wp-admin"
+    allowed_methods          = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods           = ["GET", "HEAD"]
+    target_origin_id         = "wordpress-origin"
+    viewer_protocol_policy   = "redirect-to-https"
+    compress                 = true
+    cache_policy_id          = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" # AWS Managed CachingDisabled
+    origin_request_policy_id = aws_cloudfront_origin_request_policy.wordpress.id
+
+    function_association {
+      event_type   = "viewer-request"
+      function_arn = aws_cloudfront_function.wp_admin_trailing_slash.arn
+    }
+    function_association {
+      event_type   = "viewer-response"
+      function_arn = aws_cloudfront_function.rewrite_origin_location.arn
+    }
+  }
+
   # wp-admin - no caching, use WordPress policy (origin gets Host: origin.tellerstech.com;
   # wp-config.php overrides $_SERVER['HTTP_HOST'] to www.tellerstech.com via X-CloudFront-Secret)
   ordered_cache_behavior {
@@ -287,6 +321,11 @@ resource "aws_cloudfront_distribution" "tellerstech_website" {
     compress                 = true
     cache_policy_id          = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" # AWS Managed CachingDisabled
     origin_request_policy_id = aws_cloudfront_origin_request_policy.wordpress.id
+
+    function_association {
+      event_type   = "viewer-response"
+      function_arn = aws_cloudfront_function.rewrite_origin_location.arn
+    }
   }
 
   # wp-login.php - no caching
@@ -299,6 +338,11 @@ resource "aws_cloudfront_distribution" "tellerstech_website" {
     compress                 = true
     cache_policy_id          = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" # AWS Managed CachingDisabled
     origin_request_policy_id = aws_cloudfront_origin_request_policy.wordpress.id
+
+    function_association {
+      event_type   = "viewer-response"
+      function_arn = aws_cloudfront_function.rewrite_origin_location.arn
+    }
   }
 
   # wp-json API - no caching


### PR DESCRIPTION
## Summary
- **Bug:** `https://www.tellerstech.com/wp-admin` (no trailing slash) is not matched by `/wp-admin/*`, so it used the default cache policy. Nginx issued `301 Location: https://origin.tellerstech.com/wp-admin/`; CloudFront cached it; browsers hit the secret-gated origin → **403**.
- **Fix:** CloudFront Functions to (1) redirect `/wp-admin` → `https://www.tellerstech.com/wp-admin/` and (2) rewrite any `Location` host `origin.tellerstech.com` → `www.tellerstech.com`, plus an exact `/wp-admin` CachingDisabled behavior.

## Workaround (now)
Use `https://www.tellerstech.com/wp-admin/` (trailing slash) — already works.

## Test plan
- [ ] After TFC apply: `curl -sI https://www.tellerstech.com/wp-admin` → 301 to `https://www.tellerstech.com/wp-admin/` (not origin)
- [ ] `curl -sI https://www.tellerstech.com/wp-admin/` → 302 to www wp-login
- [ ] Optional: invalidate `/wp-admin*` if any poison remains mid-deploy


Made with [Cursor](https://cursor.com)