### PR TITLE
fix(cloudfront): whitelist query strings in page cache keys

### DIFF
--- a/aws/docs/cloudfront-tellerstech-502-troubleshooting.md
+++ b/aws/docs/cloudfront-tellerstech-502-troubleshooting.md
@@ -13,6 +13,14 @@ When the site returns **502 Bad Gateway** from CloudFront, the failure is betwee
 
 CloudFront therefore connects to **https://origin.tellerstech.com** and sends the secret header. The server must respond successfully to that request.
 
+## Cache key vs query-string floods
+
+WordPress and podcast cache policies put only **functional** query strings (`s`,
+`p`, `paged`, preview, etc.) in the cache key. Marketing / random params
+(`utm_*`, `gclid`, `fbclid`, unique junk) share the same cached object as the
+clean URL, so a scrape of `/?x=<random>` cannot force a miss per request.
+Origin request policy still forwards **all** query strings on a cache miss.
+
 ## wp-admin redirects to origin (403)
 
 Exact path `/wp-admin` (no trailing slash) is **not** matched by `/wp-admin/*`, so it used the default cache behavior. Nginx’s trailing-slash 301 used `Host: origin.tellerstech.com`, CloudFront cached `Location: https://origin.tellerstech.com/wp-admin/`, and browsers then hit the gated origin → **403**.

--- a/aws/global/cloudfront/tellerstech-website.tf
+++ b/aws/global/cloudfront/tellerstech-website.tf
@@ -1,10 +1,14 @@
 # CloudFront Distribution for www.tellerstech.com
 # WordPress-optimized caching with full page cache for anonymous visitors
 
-# Cache policy for WordPress - forwards session cookies to bypass cache for logged-in users
+# Cache policy for WordPress - forwards session cookies to bypass cache for logged-in users.
+# Query strings in the *cache key* are whitelisted only: marketing params (utm_*, gclid,
+# fbclid, …) must not fragment the cache or a scrape of unique ?x= values will miss-cache
+# every request and burn PHP-FPM. Origin request policy still forwards all query strings
+# on a miss so WordPress can see them when needed.
 resource "aws_cloudfront_cache_policy" "wordpress" {
   name        = "WordPress-CachePolicy"
-  comment     = "Cache policy for WordPress - bypasses cache when session cookies present"
+  comment     = "WordPress pages: session cookies + functional query strings only in cache key"
   min_ttl     = 0
   default_ttl = 7200  # 2 hours
   max_ttl     = 86400 # 1 day
@@ -29,7 +33,26 @@ resource "aws_cloudfront_cache_policy" "wordpress" {
     }
 
     query_strings_config {
-      query_string_behavior = "all"
+      query_string_behavior = "whitelist"
+      query_strings {
+        items = [
+          "s",
+          "p",
+          "page_id",
+          "page",
+          "paged",
+          "preview",
+          "preview_id",
+          "preview_nonce",
+          "order",
+          "orderby",
+          "cat",
+          "tag",
+          "author",
+          "attachment_id",
+          "replytocom",
+        ]
+      }
     }
   }
 }
@@ -40,7 +63,7 @@ resource "aws_cloudfront_cache_policy" "wordpress" {
 # keep the default 1 day ceiling.
 resource "aws_cloudfront_cache_policy" "podcast" {
   name        = "Podcast-CachePolicy"
-  comment     = "Cache policy for key Ship It Weekly landing pages - 12 hour max TTL"
+  comment     = "SIW landing pages: 12h max TTL; functional query strings only in cache key"
   min_ttl     = 0
   default_ttl = 7200  # 2 hours
   max_ttl     = 43200 # 12 hours
@@ -65,7 +88,26 @@ resource "aws_cloudfront_cache_policy" "podcast" {
     }
 
     query_strings_config {
-      query_string_behavior = "all"
+      query_string_behavior = "whitelist"
+      query_strings {
+        items = [
+          "s",
+          "p",
+          "page_id",
+          "page",
+          "paged",
+          "preview",
+          "preview_id",
+          "preview_nonce",
+          "order",
+          "orderby",
+          "cat",
+          "tag",
+          "author",
+          "attachment_id",
+          "replytocom",
+        ]
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- Change WordPress and podcast CloudFront cache policies from `query_string_behavior = all` to a **whitelist** of functional WP params (`s`, `p`, `paged`, preview, etc.).
- Marketing / random params (`utm_*`, `gclid`, unique junk) share the clean-URL cache entry, reducing origin flood risk on main pages.
- Origin request policy still forwards **all** query strings on a miss.

## Test plan
- [ ] TFC plan shows cache policy updates only (no distribution replacement surprise beyond policy association)
- [ ] After apply: `/?utm_source=test` and `/` should share cache behavior (second request likely Hit)
- [ ] `/?s=something` still distinct / searchable
- [ ] Homepage and SIW hub still 200


Made with [Cursor](https://cursor.com)