### PR TITLE
fix(cloudfront): trim cache-key query whitelist to AWS max 10

### DIFF
--- a/aws/docs/cloudfront-tellerstech-502-troubleshooting.md
+++ b/aws/docs/cloudfront-tellerstech-502-troubleshooting.md
@@ -15,11 +15,12 @@ CloudFront therefore connects to **https://origin.tellerstech.com** and sends th
 
 ## Cache key vs query-string floods
 
-WordPress and podcast cache policies put only **functional** query strings (`s`,
-`p`, `paged`, preview, etc.) in the cache key. Marketing / random params
-(`utm_*`, `gclid`, `fbclid`, unique junk) share the same cached object as the
-clean URL, so a scrape of `/?x=<random>` cannot force a miss per request.
-Origin request policy still forwards **all** query strings on a cache miss.
+WordPress and podcast cache policies put only **functional** query strings in the
+cache key (AWS soft quota: **max 10** — currently `s`, `p`, `page_id`, `page`,
+`paged`, `preview`, `preview_id`, `preview_nonce`, `order`, `orderby`). Marketing /
+random params (`utm_*`, `gclid`, `fbclid`, unique junk) share the same cached
+object as the clean URL, so a scrape of `/?x=<random>` cannot force a miss per
+request. Origin request policy still forwards **all** query strings on a cache miss.
 
 ## wp-admin redirects to origin (403)
 

--- a/aws/global/cloudfront/tellerstech-website.tf
+++ b/aws/global/cloudfront/tellerstech-website.tf
@@ -33,6 +33,7 @@ resource "aws_cloudfront_cache_policy" "wordpress" {
     }
 
     query_strings_config {
+      # Soft quota: max 10 query strings per cache policy (TooManyQueryStringsInCachePolicy).
       query_string_behavior = "whitelist"
       query_strings {
         items = [
@@ -46,11 +47,6 @@ resource "aws_cloudfront_cache_policy" "wordpress" {
           "preview_nonce",
           "order",
           "orderby",
-          "cat",
-          "tag",
-          "author",
-          "attachment_id",
-          "replytocom",
         ]
       }
     }
@@ -88,6 +84,7 @@ resource "aws_cloudfront_cache_policy" "podcast" {
     }
 
     query_strings_config {
+      # Soft quota: max 10 query strings per cache policy (TooManyQueryStringsInCachePolicy).
       query_string_behavior = "whitelist"
       query_strings {
         items = [
@@ -101,11 +98,6 @@ resource "aws_cloudfront_cache_policy" "podcast" {
           "preview_nonce",
           "order",
           "orderby",
-          "cat",
-          "tag",
-          "author",
-          "attachment_id",
-          "replytocom",
         ]
       }
     }


### PR DESCRIPTION
## Summary
- Follow-up to #90: CloudFront soft quota is **10 query strings per cache policy**.
- Dropped `cat`, `tag`, `author`, `attachment_id`, `replytocom` (pretty permalinks cover those).
- Kept: `s`, `p`, `page_id`, `page`, `paged`, `preview`, `preview_id`, `preview_nonce`, `order`, `orderby`.

## Test plan
- [ ] TFC apply succeeds for both `wordpress` and `podcast` cache policies
- [ ] Homepage / SIW hub still 200; `/?utm_source=x` still cache-friendly


Made with [Cursor](https://cursor.com)