### PR TITLE
Harden SES Gmail pipe + low-cost CloudFront defenses

### DIFF
--- a/aws/docs/cloudfront-tellerstech-502-troubleshooting.md
+++ b/aws/docs/cloudfront-tellerstech-502-troubleshooting.md
@@ -27,6 +27,12 @@ request. Origin request policy still forwards **all** query strings on a cache m
 Exact path `/wp-admin` (no trailing slash) is **not** matched by `/wp-admin/*`, so it used the default cache behavior. Nginx’s trailing-slash 301 used `Host: origin.tellerstech.com`, CloudFront cached `Location: https://origin.tellerstech.com/wp-admin/`, and browsers then hit the gated origin → **403**.
 
 **Mitigations (applied):** `aws/global/cloudfront/functions.tf` redirects `/wp-admin` → `https://www.tellerstech.com/wp-admin/` and rewrites any `Location: …origin.tellerstech.com…` → www; an exact `/wp-admin` CachingDisabled behavior avoids re-caching a bad 301. Prefer `https://www.tellerstech.com/wp-admin/` (trailing slash) as the bookmark.
+
+## xmlrpc and exact `/wp-json`
+
+- **`/xmlrpc.php`**: blocked at the edge (CloudFront Function viewer-request → **403**) and in DirectAdmin parent `tellerstech.com.cust_nginx` (nginx `return 403`). Keeps xmlrpc brute-force / amplification off PHP-FPM.
+- **Exact `/wp-json`**: `/wp-json/*` does not match `/wp-json`. An exact CachingDisabled behavior + Location rewrite (same pattern as `/wp-admin`) avoids cache poison / origin Location on the bare REST root.
+
 ## Branded error pages (www)
 
 When CloudFront cannot reach the origin or the origin returns **5xx** (500/502/503/504), viewers of **www.tellerstech.com** get static HTML from S3 (`/errors/503.html`). Status codes are unchanged (no fake 200).

--- a/aws/global/cloudfront/functions.tf
+++ b/aws/global/cloudfront/functions.tf
@@ -4,16 +4,33 @@
 # 502s). Nginx absolute redirects therefore use that host unless we rewrite them
 # at the edge. wp-config.php already fixes PHP redirects when the shared secret
 # matches; these functions cover nginx-level redirects (e.g. trailing slash).
+#
+# Max one CloudFront Function per event type per behavior — xmlrpc 403 and
+# /wp-admin trailing-slash redirect share this viewer-request function.
 
 resource "aws_cloudfront_function" "wp_admin_trailing_slash" {
   name    = "tellerstech-wp-admin-trailing-slash"
   runtime = "cloudfront-js-2.0"
-  comment = "Redirect /wp-admin → /wp-admin/ on www before nginx Host-based 301"
+  comment = "Block xmlrpc.php; redirect /wp-admin → /wp-admin/ on www"
   publish = true
   code    = <<-EOF
 function handler(event) {
   var request = event.request;
-  if (request.uri === '/wp-admin') {
+  var uri = request.uri;
+
+  // WordPress xmlrpc is a common brute-force / amplification vector; never origin.
+  if (uri === '/xmlrpc.php' || uri.indexOf('/xmlrpc.php?') === 0) {
+    return {
+      statusCode: 403,
+      statusDescription: 'Forbidden',
+      headers: {
+        'content-type': { value: 'text/plain' }
+      },
+      body: 'Forbidden'
+    };
+  }
+
+  if (uri === '/wp-admin') {
     var location = 'https://www.tellerstech.com/wp-admin/';
     var parts = [];
     Object.keys(request.querystring).forEach(function (key) {

--- a/aws/global/cloudfront/tellerstech-website.tf
+++ b/aws/global/cloudfront/tellerstech-website.tf
@@ -379,6 +379,25 @@ resource "aws_cloudfront_distribution" "tellerstech_website" {
     }
   }
 
+  # Exact /wp-json (no trailing path). /wp-json/* does NOT match this path, so
+  # without this block it used the default cache policy — same class of bug as
+  # exact /wp-admin (cached origin Location / odd redirects on the API root).
+  ordered_cache_behavior {
+    path_pattern             = "/wp-json"
+    allowed_methods          = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods           = ["GET", "HEAD"]
+    target_origin_id         = "wordpress-origin"
+    viewer_protocol_policy   = "redirect-to-https"
+    compress                 = true
+    cache_policy_id          = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" # AWS Managed CachingDisabled
+    origin_request_policy_id = aws_cloudfront_origin_request_policy.wordpress.id
+
+    function_association {
+      event_type   = "viewer-response"
+      function_arn = aws_cloudfront_function.rewrite_origin_location.arn
+    }
+  }
+
   # wp-json API - no caching
   ordered_cache_behavior {
     path_pattern             = "/wp-json/*"
@@ -389,6 +408,11 @@ resource "aws_cloudfront_distribution" "tellerstech_website" {
     compress                 = true
     cache_policy_id          = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" # AWS Managed CachingDisabled
     origin_request_policy_id = aws_cloudfront_origin_request_policy.wordpress.id
+
+    function_association {
+      event_type   = "viewer-response"
+      function_arn = aws_cloudfront_function.rewrite_origin_location.arn
+    }
   }
 
   # wp-cron.php - no caching

--- a/aws/global/ses/da-gmail-forward.tf
+++ b/aws/global/ses/da-gmail-forward.tf
@@ -1,8 +1,8 @@
 # DirectAdmin → SES Gmail forward (canonical TellersTech mail path).
 #
-# MX stays on DirectAdmin. Server pipe script:
-#   scripts/directadmin/ses_gmail_forward.py
-# delivers via dovecot-lda (Roundcube) then SES SendRawEmail (Gmail copy).
+# MX stays on DirectAdmin. Exim Email Account → Roundcube (LMTP);
+# Forwarder pipe → scripts/directadmin/ses_gmail_forward.py → SES → Gmail.
+# The pipe must NOT call dovecot-lda (always exit 0).
 #
 # Runtime config secret is always provisioned. Populate in AWS console / CLI;
 # Terraform ignores secret_string changes after create. No addresses in git.

--- a/scripts/directadmin/ses_gmail_forward.md
+++ b/scripts/directadmin/ses_gmail_forward.md
@@ -92,7 +92,7 @@ chmod 777 /var/lib/ses-gmail-forward
 python3 -c 'import boto3; print(boto3.__version__)'
 # Alma/Rocky: dnf install -y python3-boto3
 
-# Health check (self-heal aliases + alert on recent ERROR)
+# Health check (self-heal aliases + alert on recent ERROR / silent SES skips)
 curl -fsSL -o /usr/local/bin/ses-gmail-forward-health.sh \
   https://raw.githubusercontent.com/wbat/wbat-terraform/main/scripts/directadmin/ses_gmail_forward_health.sh
 chmod 755 /usr/local/bin/ses-gmail-forward-health.sh
@@ -102,6 +102,32 @@ echo '*/5 * * * * root /usr/local/bin/ses-gmail-forward-health.sh' \
   >/etc/cron.d/ses-gmail-forward-health
 chmod 644 /etc/cron.d/ses-gmail-forward-health
 ```
+
+After merging pipe/health changes, re-copy both scripts to `/usr/local/bin/` on the
+server (`install -m 755 …`). No service restart is required for the pipe.
+
+## Skip guards (pipe → SES)
+
+Before `SendRawEmail`, the pipe logs `WARNING skip_ses reason=…` and exits 0
+(Roundcube already has the message via Exim). Health alerts on
+`rate_limit`, `ses_error`, `config_error`, and `missing_gmail_dest`.
+
+| `reason=` | Meaning |
+|---|---|
+| `auto_submitted` | `Auto-Submitted` present and not `no` |
+| `auto_response_suppress` | `X-Auto-Response-Suppress` present |
+| `precedence` | `Precedence: bulk\|list\|junk` |
+| `pipe_reentry` | `X-Forwarded-For` / `X-Forwarded-To` already set (this pipe) |
+| `from_gmail_dest` | From/Sender/Reply-To is the Gmail destination |
+| `mailer_daemon` | From looks like mailer-daemon / postmaster |
+| `rate_limit` | Per-recipient or global hourly cap |
+| `ses_error` | `SendRawEmail` failed |
+| `oversized` / `missing_headers` / `empty_payload` | Message rejected before SES |
+
+`List-Unsubscribe` alone is **not** a skip reason (newsletters are legitimate).
+
+Rate-limit counters increment **only after a successful** `SendRawEmail`, so SES
+failures do not burn quota.
 
 ## Gmail (outbound)
 

--- a/scripts/directadmin/ses_gmail_forward.md
+++ b/scripts/directadmin/ses_gmail_forward.md
@@ -115,8 +115,6 @@ Before `SendRawEmail`, the pipe logs `WARNING skip_ses reason=…` and exits 0
 | `reason=` | Meaning |
 |---|---|
 | `auto_submitted` | `Auto-Submitted` present and not `no` |
-| `auto_response_suppress` | `X-Auto-Response-Suppress` present |
-| `precedence` | `Precedence: bulk\|list\|junk` |
 | `pipe_reentry` | `X-Ses-Gmail-Forward: 1` already set (this pipe; not generic `X-Forwarded-*`) |
 | `from_gmail_dest` | From/Sender/Reply-To is the Gmail destination |
 | `mailer_daemon` | From looks like mailer-daemon / postmaster |
@@ -124,7 +122,8 @@ Before `SendRawEmail`, the pipe logs `WARNING skip_ses reason=…` and exits 0
 | `ses_error` | `SendRawEmail` failed |
 | `oversized` / `missing_headers` / `empty_payload` | Message rejected before SES |
 
-`List-Unsubscribe` alone is **not** a skip reason (newsletters are legitimate).
+`Precedence`, `List-Unsubscribe`, and `X-Auto-Response-Suppress` alone are **not**
+skip reasons — newsletters and list mail commonly set them and should still reach Gmail.
 
 Rate-limit counters increment **only after a successful** `SendRawEmail`, so SES
 failures do not burn quota.

--- a/scripts/directadmin/ses_gmail_forward.md
+++ b/scripts/directadmin/ses_gmail_forward.md
@@ -117,7 +117,7 @@ Before `SendRawEmail`, the pipe logs `WARNING skip_ses reason=…` and exits 0
 | `auto_submitted` | `Auto-Submitted` present and not `no` |
 | `auto_response_suppress` | `X-Auto-Response-Suppress` present |
 | `precedence` | `Precedence: bulk\|list\|junk` |
-| `pipe_reentry` | `X-Forwarded-For` / `X-Forwarded-To` already set (this pipe) |
+| `pipe_reentry` | `X-Ses-Gmail-Forward: 1` already set (this pipe; not generic `X-Forwarded-*`) |
 | `from_gmail_dest` | From/Sender/Reply-To is the Gmail destination |
 | `mailer_daemon` | From looks like mailer-daemon / postmaster |
 | `rate_limit` | Per-recipient or global hourly cap |

--- a/scripts/directadmin/ses_gmail_forward.py
+++ b/scripts/directadmin/ses_gmail_forward.py
@@ -49,8 +49,10 @@ SECRET_ID = os.environ.get(
 STATE_DIR = Path(os.environ.get("SES_GMAIL_FORWARD_STATE", "/var/lib/ses-gmail-forward"))
 AWS_REGION = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
 
-# Marker headers this pipe sets — presence means re-entry / loop.
-_PIPE_MARKERS = ("X-Forwarded-For", "X-Forwarded-To")
+# Pipe-specific re-entry marker (do NOT use generic X-Forwarded-* — those are
+# set by legitimate upstream forwards and would silently skip Gmail copies).
+_PIPE_MARKER_HEADER = "X-Ses-Gmail-Forward"
+_PIPE_MARKER_VALUE = "1"
 _MAILER_DAEMON_RE = re.compile(
     r"(?i)^(mailer-daemon|postmaster|mail-daemon|majordomo)(@|$)",
 )
@@ -175,9 +177,9 @@ def _should_skip_forward(mail_obj: email.message.Message, gmail_dest: str) -> st
     if prec in ("bulk", "list", "junk"):
         return "precedence"
 
-    for marker in _PIPE_MARKERS:
-        if mail_obj.get(marker):
-            return "pipe_reentry"
+    marker = (mail_obj.get(_PIPE_MARKER_HEADER) or "").strip()
+    if marker == _PIPE_MARKER_VALUE:
+        return "pipe_reentry"
 
     gmail_dest_l = gmail_dest.strip().lower()
     for addr in _addrs_in(mail_obj, "From", "Sender", "Reply-To"):
@@ -269,6 +271,7 @@ def _build_forward_raw(original: email.message.Message, from_addr: str, gmail_de
     msg["X-Original-From"] = original_from
     msg["X-Forwarded-To"] = gmail_dest
     msg["X-Forwarded-For"] = from_addr
+    msg[_PIPE_MARKER_HEADER] = _PIPE_MARKER_VALUE
     return msg.as_bytes()
 
 

--- a/scripts/directadmin/ses_gmail_forward.py
+++ b/scripts/directadmin/ses_gmail_forward.py
@@ -165,17 +165,14 @@ def _addrs_in(mail_obj: email.message.Message, *headers: str) -> list[str]:
 
 
 def _should_skip_forward(mail_obj: email.message.Message, gmail_dest: str) -> str | None:
-    """Return skip reason, or None if the message may be forwarded to SES."""
+    """Return skip reason, or None if the message may be forwarded to SES.
+
+    Do not skip on Precedence / List-Unsubscribe / X-Auto-Response-Suppress alone —
+    those are common on legitimate newsletters and list mail.
+    """
     auto = (mail_obj.get("Auto-Submitted") or "").strip().lower()
     if auto and auto != "no":
         return "auto_submitted"
-
-    if mail_obj.get("X-Auto-Response-Suppress"):
-        return "auto_response_suppress"
-
-    prec = (mail_obj.get("Precedence") or "").strip().lower()
-    if prec in ("bulk", "list", "junk"):
-        return "precedence"
 
     marker = (mail_obj.get(_PIPE_MARKER_HEADER) or "").strip()
     if marker == _PIPE_MARKER_VALUE:

--- a/scripts/directadmin/ses_gmail_forward.py
+++ b/scripts/directadmin/ses_gmail_forward.py
@@ -31,6 +31,7 @@ import email.utils
 import json
 import logging
 import os
+import re
 import sys
 import time
 from datetime import datetime, timezone
@@ -47,6 +48,12 @@ SECRET_ID = os.environ.get(
 )
 STATE_DIR = Path(os.environ.get("SES_GMAIL_FORWARD_STATE", "/var/lib/ses-gmail-forward"))
 AWS_REGION = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
+
+# Marker headers this pipe sets — presence means re-entry / loop.
+_PIPE_MARKERS = ("X-Forwarded-For", "X-Forwarded-To")
+_MAILER_DAEMON_RE = re.compile(
+    r"(?i)^(mailer-daemon|postmaster|mail-daemon|majordomo)(@|$)",
+)
 
 
 def _setup_logging() -> logging.Logger:
@@ -89,6 +96,16 @@ def _config() -> dict:
 
 def _allowlist(cfg: dict) -> set[str]:
     return {a.strip().lower() for a in (cfg.get("recipients") or []) if a}
+
+
+def _log_skip(reason: str, recipient: str = "", **extra: str) -> None:
+    parts = [f"skip_ses reason={reason}"]
+    if recipient:
+        parts.append(f"recipient={recipient}")
+    for k, v in extra.items():
+        if v:
+            parts.append(f"{k}={v}")
+    logger.warning(" ".join(parts))
 
 
 def _addresses_from_headers(mail_obj: email.message.Message) -> list[str]:
@@ -135,24 +152,78 @@ def _resolve_recipient(argv: list[str], mail_obj: email.message.Message, allow: 
     return None
 
 
-def _rate_ok(key: str, limit: int) -> bool:
+def _addrs_in(mail_obj: email.message.Message, *headers: str) -> list[str]:
+    out: list[str] = []
+    for header in headers:
+        for value in mail_obj.get_all(header) or []:
+            for _, addr in email.utils.getaddresses([value]):
+                if addr:
+                    out.append(addr.strip().lower())
+    return out
+
+
+def _should_skip_forward(mail_obj: email.message.Message, gmail_dest: str) -> str | None:
+    """Return skip reason, or None if the message may be forwarded to SES."""
+    auto = (mail_obj.get("Auto-Submitted") or "").strip().lower()
+    if auto and auto != "no":
+        return "auto_submitted"
+
+    if mail_obj.get("X-Auto-Response-Suppress"):
+        return "auto_response_suppress"
+
+    prec = (mail_obj.get("Precedence") or "").strip().lower()
+    if prec in ("bulk", "list", "junk"):
+        return "precedence"
+
+    for marker in _PIPE_MARKERS:
+        if mail_obj.get(marker):
+            return "pipe_reentry"
+
+    gmail_dest_l = gmail_dest.strip().lower()
+    for addr in _addrs_in(mail_obj, "From", "Sender", "Reply-To"):
+        if addr == gmail_dest_l:
+            return "from_gmail_dest"
+        if _MAILER_DAEMON_RE.search(addr):
+            return "mailer_daemon"
+
+    return None
+
+
+def _rate_path(key: str) -> Path:
+    hour = datetime.now(timezone.utc).strftime("%Y%m%d%H")
+    return STATE_DIR / f"rate-{key.replace('/', '_')}-{hour}.count"
+
+
+def _rate_check(key: str, limit: int) -> bool:
+    """True if under limit (does not increment). Fail-open if state unwritable."""
     try:
         STATE_DIR.mkdir(parents=True, exist_ok=True)
-        hour = datetime.now(timezone.utc).strftime("%Y%m%d%H")
-        path = STATE_DIR / f"rate-{key.replace('/', '_')}-{hour}.count"
+        path = _rate_path(key)
         try:
             count = int(path.read_text().strip() or "0")
         except FileNotFoundError:
             count = 0
         except OSError:
             count = 0
-        if count >= limit:
-            return False
-        path.write_text(str(count + 1))
-        return True
+        return count < limit
     except OSError:
         logger.warning("Rate-limit state unwritable; allowing send")
         return True
+
+
+def _rate_increment(key: str) -> None:
+    try:
+        STATE_DIR.mkdir(parents=True, exist_ok=True)
+        path = _rate_path(key)
+        try:
+            count = int(path.read_text().strip() or "0")
+        except FileNotFoundError:
+            count = 0
+        except OSError:
+            count = 0
+        path.write_text(str(count + 1))
+    except OSError:
+        logger.warning("Rate-limit state unwritable; could not increment")
 
 
 def _has_payload(msg: email.message.Message) -> bool:
@@ -210,18 +281,18 @@ def _send_ses(
 ) -> bool:
     max_bytes = int(cfg.get("max_message_bytes") or 10 * 1024 * 1024)
     if len(raw) > max_bytes:
-        logger.warning("Message oversized (%s bytes); skip SES", len(raw))
+        _log_skip("oversized", recipient, bytes=str(len(raw)))
         return False
     per_recip = int(cfg.get("rate_limit_per_recipient_per_hour") or 30)
     global_lim = int(cfg.get("rate_limit_global_per_hour") or 100)
-    if not _rate_ok(f"r-{recipient}", per_recip) or not _rate_ok("global", global_lim):
-        logger.warning("Rate limit exceeded for %s; skip SES", recipient)
+    if not _rate_check(f"r-{recipient}", per_recip) or not _rate_check("global", global_lim):
+        _log_skip("rate_limit", recipient)
         return False
     if not (mail_obj.get("From") and mail_obj.get("Date")):
-        logger.warning("Missing From/Date; skip SES")
+        _log_skip("missing_headers", recipient)
         return False
     if not _has_payload(mail_obj):
-        logger.warning("Empty payload; skip SES")
+        _log_skip("empty_payload", recipient)
         return False
     try:
         ses.send_raw_email(
@@ -229,10 +300,13 @@ def _send_ses(
             Destinations=[gmail_dest],
             RawMessage={"Data": _build_forward_raw(mail_obj, recipient, gmail_dest)},
         )
+        _rate_increment(f"r-{recipient}")
+        _rate_increment("global")
         logger.info("Forwarded SES copy for %s", recipient)
         return True
     except ClientError:
         logger.exception("SES SendRawEmail failed")
+        _log_skip("ses_error", recipient)
         return False
 
 
@@ -240,13 +314,14 @@ def main(argv: list[str]) -> int:
     # Always return 0: non-zero makes Exim bounce even when Roundcube already has mail.
     raw = sys.stdin.buffer.read()
     if not raw:
-        logger.warning("Empty stdin; skip")
+        _log_skip("empty_stdin")
         return 0
 
     try:
         cfg = _config()
     except ClientError:
         logger.exception("Failed to load runtime config")
+        _log_skip("config_error")
         return 0
 
     allow = _allowlist(cfg)
@@ -254,16 +329,24 @@ def main(argv: list[str]) -> int:
     recipient = _resolve_recipient(argv, mail_obj, allow)
     if not recipient:
         logger.error("Could not resolve recipient for SES forward")
+        _log_skip("no_recipient")
         return 0
 
     gmail_dest = (cfg.get("gmail_destination") or "").strip()
-    if recipient in allow and gmail_dest:
-        _send_ses(mail_obj, raw, recipient, gmail_dest, cfg)
-    elif recipient not in allow:
+    if recipient not in allow:
         logger.info("Recipient not in SES allowlist; skip SES (Roundcube via Exim)")
-    else:
+        return 0
+    if not gmail_dest:
         logger.error("gmail_destination missing in runtime config")
+        _log_skip("missing_gmail_dest", recipient)
+        return 0
 
+    skip = _should_skip_forward(mail_obj, gmail_dest)
+    if skip:
+        _log_skip(skip, recipient)
+        return 0
+
+    _send_ses(mail_obj, raw, recipient, gmail_dest, cfg)
     return 0
 
 

--- a/scripts/directadmin/ses_gmail_forward_health.sh
+++ b/scripts/directadmin/ses_gmail_forward_health.sh
@@ -52,23 +52,30 @@ if [[ -x "$ALIASES_ENSURE" ]]; then
   }
 fi
 
-# 4) Recent ERROR lines in forward log (pipe failures / SES)
+# 4) Recent ERROR / silent-skip lines in forward log (pipe failures / SES)
 if [[ -f "$FORWARD_LOG" ]]; then
-  # GNU find -mmin on the log isn't enough; scan recent ERROR lines by timestamp prefix.
+  # GNU find -mmin on the log isn't enough; scan recent lines by timestamp prefix.
   cutoff="$(date -d "-${WINDOW_MINUTES} minutes" '+%Y-%m-%d %H:%M:%S' 2>/dev/null || date -v-"${WINDOW_MINUTES}"M '+%Y-%m-%d %H:%M:%S')"
   # shellcheck disable=SC2016
-  recent_errors="$(awk -v c="$cutoff" '
-    $0 ~ / ERROR / {
+  recent_bad="$(awk -v c="$cutoff" '
+    {
+      ts = substr($0, 1, 19)
+      if (ts < c) next
       # Obsolete path: lda under pipe as user mail (fixed; ignore historical noise)
       if ($0 ~ /dovecot-lda failed/) next
-      ts = substr($0, 1, 19)
-      if (ts >= c) print
+      if ($0 ~ / ERROR /) { print; next }
+      # Structured skips that mean Gmail never got a copy (alert-worthy)
+      if ($0 ~ /skip_ses reason=(rate_limit|ses_error|config_error|missing_gmail_dest)/) { print; next }
+      if ($0 ~ /Rate limit exceeded/) { print; next }
+      if ($0 ~ /SES SendRawEmail failed/) { print; next }
+      if ($0 ~ /gmail_destination missing/) { print; next }
+      if ($0 ~ /Failed to load runtime config/) { print; next }
     }
   ' "$FORWARD_LOG" | tail -20)"
-  if [[ -n "$recent_errors" ]]; then
+  if [[ -n "$recent_bad" ]]; then
     fail=1
-    reasons+=("recent_forward_errors")
-    log "RECENT_ERRORS:"$'\n'"$recent_errors"
+    reasons+=("recent_forward_errors_or_skips")
+    log "RECENT_BAD:"$'\n'"$recent_bad"
   fi
 fi
 


### PR DESCRIPTION
## Summary
- SES pipe: skip auto-replies/loops (`skip_ses reason=…`), increment rate limits only after successful SendRawEmail, health alerts on rate_limit/SES/config skips
- CloudFront: merge xmlrpc.php → 403 into viewer-request function; exact `/wp-json` CachingDisabled + Location rewrite
- Docs: mail skip reasons + deploy note; 502 runbook; fix stale dovecot-lda comment in `da-gmail-forward.tf`

## Test plan
- [ ] Feed bounce/auto-reply sample to pipe → `skip_ses reason=…`, exit 0, no SES call
- [ ] Confirm failed SES does not increment rate counter; success does
- [ ] Inject matching WARNING into forward log → health fail (+ alert if `HEALTH_ALERT_TO` set)
- [ ] After TF apply: `curl -sI https://www.tellerstech.com/xmlrpc.php` → 403
- [ ] After TF apply: `curl -sI https://www.tellerstech.com/wp-json` → no cached origin Location

## After merge
- Copy updated `ses_gmail_forward.py` + `ses_gmail_forward_health.sh` to `/usr/local/bin/` on the DA server (`install -m 755 …`); no restart needed
- Apply terraform for CloudFront; refresh cust_nginx via website installer (companion PR)


Made with [Cursor](https://cursor.com)