### PR TITLE
Set up Cursor Cloud dev environment (Terraform 1.15.7 + AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is **Terraform Infrastructure as Code** (no runnable app). Real applies happen in **HCP Terraform**, not locally. There are three independent workspaces: `aws/`, `github/`, `tfc/`. All modules are local paths (no git/SSH module sources), so init/validate work offline without any secrets.
+
+### Toolchain
+- Terraform is pinned to the version in `.terraform-version` (currently `1.15.7`). The startup update script installs it to `/usr/local/bin/terraform`.
+- `python3` + `PyYAML` are already present in the base image (used only by optional `scripts/`).
+
+### Lint / validate / "build" (the core dev loop)
+- Lint (from repo root): `terraform fmt -recursive -check`
+- Per workspace validate (run inside `aws/`, `github/`, or `tfc/`):
+  - `terraform init -backend=false` then `terraform validate`
+- Use `-backend=false` for local validation. Plain `terraform init` (and any `plan`/`apply`) targets the HCP Terraform cloud backend and needs a `TFC_API_TOKEN`; do not attempt real plan/apply here. CI mirrors this: fmt from root + init/validate per workspace (see `.github/workflows/terraform_ci.yml`).
+
+### Gotchas
+- `terraform init` appends a platform-specific `h1:` hash to each `.terraform.lock.hcl`. This is local noise — do not commit it (revert with `git checkout -- '*/.terraform.lock.hcl'`).
+- No automated test suite exists; validation = `fmt -check` + `validate` across the three workspaces.
+- `scripts/` (EC2 volume-shrink migration tooling) is optional ops tooling, not part of the Terraform loop; it only needs `python3` + `PyYAML`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for this Terraform IaC repo so future Cursor Cloud agents can lint and validate all three workspaces out of the box.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section documenting the toolchain, the fmt/validate dev loop, and non-obvious gotchas.
- Configures the VM startup update script to install the pinned Terraform version (`1.15.7`, from `.terraform-version`) idempotently.

No infrastructure code was changed.

## Verification

- `terraform fmt -recursive -check` (repo root) → OK
- `terraform init -backend=false` + `terraform validate` for `aws/`, `github/`, `tfc/` → all `Success! The configuration is valid.`

All modules are local paths, so init/validate run offline without any secrets. Real `plan`/`apply` still runs through HCP Terraform and is out of scope for local dev.

[Terraform verification output](https://cursor.com/agents/bc-58b553d8-26a6-4874-b806-312647bb3732/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fterraform_verification.txt)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-58b553d8-26a6-4874-b806-312647bb3732"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-58b553d8-26a6-4874-b806-312647bb3732"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

