### PR TITLE
docs(da): record cutover .87 Linked IP cleanup

### DIFF
--- a/aws/docs/da-vhost-listen-change-window.md
+++ b/aws/docs/da-vhost-listen-change-window.md
@@ -107,23 +107,51 @@ nginx -t && systemctl reload nginx
 ### Unlink a stale Linked IP (do **not** use task.queue delete)
 
 On this DA build, `action=linked_ips&ip_action=delete&...` in `task.queue` is a no-op
-(`dataskq: unknown taskq action`). Unlink via Admin UI (**IP Management** → EIP →
-Linked IPs → remove) or edit the EIP’s IP file, then rewrite:
+(`dataskq: unknown taskq action`). Prefer Admin UI (**IP Management** → EIP → Linked IPs →
+remove), **or** the file edit below. Do not proceed to `ip addr del` / reload until the
+stale address is gone from `linked_ips` and from `nginx -T`.
 
 ```bash
 EIP=44.214.133.234
 STALE=172.30.0.87   # example: forgotten cutover private IP
 KEEP=172.30.0.71    # must remain linked
+EIP_FILE=/usr/local/directadmin/data/admin/ips/$EIP
 
-# Backup, then set linked_ips to KEEP only (URL-encoding matches DA):
-#   linked_ips=<urlencoded KEEP>=apache%3Dyes%26dns%3Dno
-# File: /usr/local/directadmin/data/admin/ips/$EIP  (diradmin:diradmin, mode 600)
+cp -a "$EIP_FILE" "${EIP_FILE}.bak-$(date -u +%Y%m%dT%H%M%SZ)"
+
+# Rewrite linked_ips to KEEP only (DA stores IP percent-encoded; '=' before flags stays).
+python3 - <<PY
+import pathlib, urllib.parse
+path = pathlib.Path("$EIP_FILE")
+keep, stale = "$KEEP", "$STALE"
+text = path.read_text().splitlines()
+enc = urllib.parse.quote(keep, safe="") + "=" + urllib.parse.quote("apache=yes&dns=no", safe="")
+out = []
+for line in text:
+    if line.startswith("linked_ips="):
+        out.append("linked_ips=" + enc)
+    else:
+        out.append(line)
+path.write_text("\\n".join(out) + "\\n")
+raw = urllib.parse.unquote(enc)
+assert keep in raw and stale not in raw, raw
+print("linked_ips now:", raw)
+PY
+chown diradmin:diradmin "$EIP_FILE"
+chmod 600 "$EIP_FILE"
 
 /usr/local/directadmin/directadmin taskq --run 'action=rewrite&value=httpd'
+
+# Gate: configs must no longer listen on STALE before touching the NIC / reload.
+count=$(nginx -T 2>/dev/null | grep -c "listen ${STALE}" || true)
+if [ "$count" -ne 0 ]; then
+  echo "ERROR: still $count listen lines for $STALE — aborting (restore $EIP_FILE.bak-*)" >&2
+  exit 1
+fi
+
 ip addr del "${STALE}/24" dev eth0 2>/dev/null || true
-# If the stale IP is status=free and not in ip.list, remove
-#   /usr/local/directadmin/data/admin/ips/$STALE
-nginx -T 2>/dev/null | grep -c "listen ${STALE}"   # expect 0
+# If the stale IP is status=free and not in ip.list:
+#   mv /usr/local/directadmin/data/admin/ips/$STALE /var/backups/da-vhost-listen/
 nginx -t && systemctl reload nginx
 ```
 

--- a/aws/docs/da-vhost-listen-change-window.md
+++ b/aws/docs/da-vhost-listen-change-window.md
@@ -2,6 +2,24 @@
 
 Primary only. No `server2` rehearsal. Backups + `nginx -t` gate + revert on failure.
 
+## Status (2026-07-26)
+
+Done on primary (`server.wbat.net` / `i-0118b8ede80b52ef7`):
+
+| Step | Result |
+|------|--------|
+| Link arrival IP `172.30.0.71` to EIP `44.214.133.234` (`apache=yes`, `dns=no`) | Done |
+| Set `lan_ip=172.30.0.71` | Done |
+| Retire tellerstech loopback fixer | Done |
+| Unlink stale cutover IP `172.30.0.87` + remove eth0 secondary + drop free DA IP object | Done (backup under `/var/backups/da-vhost-listen/unlink87-20260727T004556Z`) |
+
+Primary now matches **server2**’s pattern: one EIP ↔ one AWS private IP only.
+`server2` (`34.205.151.236` ↔ `172.30.0.57`) was already clean and needed no change.
+
+`172.30.0.87` was the old primary’s private IP before the 2026-06-30 shrink cutover
+(large volume → 200 GB instance). It was never reassigned on the new ENI; leaving it
+linked was forgotten cleanup, not required for traffic once `.71` was linked.
+
 ## Preflight
 
 1. SSM session to primary (`i-0118b8ede80b52ef7` / `server.wbat.net`).
@@ -71,21 +89,41 @@ echo "action=ipmanager&type=api&method=POST&command=CMD_API_IP_MANAGER&action=ad
   >> /usr/local/directadmin/data/task.queue
 
 # 2) Link arrival IP to EIP; apply to existing domains; keep private IP out of DNS
+#    (task.queue linked_ips *add* works on this DA build)
 echo "action=linked_ips&ip_action=add&ip=44.214.133.234&ip_to_link=172.30.0.71&apache=yes&dns=no&apply=yes" \
   >> /usr/local/directadmin/data/task.queue
 
-# 3) Drop stale .87 link
-echo "action=linked_ips&ip_action=delete&ip=44.214.133.234&ip_to_link=172.30.0.87&apache=yes&dns=no&apply=yes" \
-  >> /usr/local/directadmin/data/task.queue
-
-# 4) lan_ip
+# 3) lan_ip
 sed -i 's/^lan_ip=.*/lan_ip=172.30.0.71/' /usr/local/directadmin/conf/directadmin.conf
 
-# 5) Drain queue + synchronous rewrite
+# 4) Drain queue + synchronous rewrite
 /usr/local/directadmin/directadmin taskq --run-all
 /usr/local/directadmin/directadmin taskq --run 'action=rewrite&value=httpd'
 
-# 6) Gate
+# 5) Gate
+nginx -t && systemctl reload nginx
+```
+
+### Unlink a stale Linked IP (do **not** use task.queue delete)
+
+On this DA build, `action=linked_ips&ip_action=delete&...` in `task.queue` is a no-op
+(`dataskq: unknown taskq action`). Unlink via Admin UI (**IP Management** → EIP →
+Linked IPs → remove) or edit the EIP’s IP file, then rewrite:
+
+```bash
+EIP=44.214.133.234
+STALE=172.30.0.87   # example: forgotten cutover private IP
+KEEP=172.30.0.71    # must remain linked
+
+# Backup, then set linked_ips to KEEP only (URL-encoding matches DA):
+#   linked_ips=<urlencoded KEEP>=apache%3Dyes%26dns%3Dno
+# File: /usr/local/directadmin/data/admin/ips/$EIP  (diradmin:diradmin, mode 600)
+
+/usr/local/directadmin/directadmin taskq --run 'action=rewrite&value=httpd'
+ip addr del "${STALE}/24" dev eth0 2>/dev/null || true
+# If the stale IP is status=free and not in ip.list, remove
+#   /usr/local/directadmin/data/admin/ips/$STALE
+nginx -T 2>/dev/null | grep -c "listen ${STALE}"   # expect 0
 nginx -t && systemctl reload nginx
 ```
 
@@ -119,7 +157,8 @@ renewal required once vhost matching is restored.
 
 ```bash
 # restore backups from /var/backups/da-vhost-listen/<stamp>
-# unlink .71 / re-link .87 as needed, restore lan_ip, rewrite, nginx -t, reload
+# (for the .87 unlink specifically: unlink87-20260727T004556Z)
+# restore EIP linked_ips / lan_ip / ips/* as needed, rewrite, nginx -t, reload
 /usr/local/directadmin/directadmin taskq --run 'action=rewrite&value=httpd'
 nginx -t && systemctl reload nginx
 ```

--- a/aws/docs/nginx-vhost-catchall-regression.md
+++ b/aws/docs/nginx-vhost-catchall-regression.md
@@ -114,6 +114,11 @@ procedure (backups, hand-patch cron disable ordering, `nginx -t` gate, rollback)
 
 → [`da-vhost-listen-change-window.md`](da-vhost-listen-change-window.md)
 
+**Applied 2026-07-26:** Linked IP / `lan_ip` set to `172.30.0.71`. Stale cutover private IP
+`172.30.0.87` (old primary before the shrink volume cutover) was later unlinked and removed
+from eth0 so primary matches server2: one EIP ↔ one real private IP only. See the change
+window **Status** section; do not use `task.queue` `linked_ips` delete on this DA build.
+
 Known-bad `nginx -T` captured before the fix (offline detector fixture):
 
 → [`fixtures/nginx-catchall-broken-2026-07-26/`](fixtures/nginx-catchall-broken-2026-07-26/)


### PR DESCRIPTION
## Summary
- Record that primary Linked IP / `lan_ip` fix is done and stale cutover IP `172.30.0.87` was unlinked (matches server2: one EIP ↔ one private IP).
- Replace the broken `task.queue` `linked_ips` delete instructions with the working unlink path (UI or EIP `linked_ips` file edit + rewrite).
- Note backup location and rollback pointer for the unlink window.

## Test plan
- [x] On-box: Linked IP only `.71`; no eth0 `.87`; `listen .87` count 0; reconciler `--check` OK
- [x] External: `check-vhost-listeners.sh` PASS for hosted domains; bogus SNI still catch-all
- [x] CloudFront: `www.tellerstech.com` 200; `origin.tellerstech.com` 403 without gate header
- [ ] Skim updated change-window Status + unlink section for accuracy


Made with [Cursor](https://cursor.com)