### PR TITLE
fix(cloudfront): bound header-less responses to a minute so a poisoned page cannot outlive the good one

### DIFF
--- a/aws/global/cloudfront/tellerstech-website.tf
+++ b/aws/global/cloudfront/tellerstech-website.tf
@@ -6,11 +6,21 @@
 # fbclid, …) must not fragment the cache or a scrape of unique ?x= values will miss-cache
 # every request and burn PHP-FPM. Origin request policy still forwards all query strings
 # on a miss so WordPress can see them when needed.
+#
+# default_ttl is deliberately short. It applies only to responses the origin sends
+# with no cache-control, and every healthy page here sets its own (max-age=300 on the
+# homepage and the two news hubs, 86400 on the rest), so it governs exactly one thing:
+# how long a response that arrives without the header stays cached. The empty-gzip
+# fault produces precisely that -- a 20-byte gzip body carrying no cache-control -- so
+# at the previous 2 hours a single poisoned object served a blank homepage to every
+# gzip-speaking browser, while the healthy variant beside it expired every 5 minutes.
+# One minute bounds the episode without changing the lifetime of any healthy response.
+# See docs/empty-gzip-page-cache.md in the tellerstech-website repo.
 resource "aws_cloudfront_cache_policy" "wordpress" {
   name        = "WordPress-CachePolicy"
   comment     = "WordPress pages: session cookies + functional query strings only in cache key"
   min_ttl     = 0
-  default_ttl = 7200  # 2 hours
+  default_ttl = 60    # only applies with no origin cache-control -- see above
   max_ttl     = 86400 # 1 day
 
   parameters_in_cache_key_and_forwarded_to_origin {
@@ -73,11 +83,15 @@ resource "aws_cloudfront_cache_policy" "wordpress" {
 # media kit) - same as WordPress policy but capped at 12 hours so these pages
 # refresh at least twice a day. Individual episodes are NOT included here and
 # keep the default 1 day ceiling.
+#
+# default_ttl matches the WordPress policy's one-minute bound, for the same reason:
+# these pages come from the same origin and can be poisoned the same way. Every
+# occurrence so far has been the homepage, but nothing about the fault is path-specific.
 resource "aws_cloudfront_cache_policy" "podcast" {
   name        = "Podcast-CachePolicy"
   comment     = "SIW landing pages: 12h max TTL; functional query strings only in cache key"
   min_ttl     = 0
-  default_ttl = 7200  # 2 hours
+  default_ttl = 60    # same bound as the WordPress policy -- see above
   max_ttl     = 43200 # 12 hours
 
   parameters_in_cache_key_and_forwarded_to_origin {


### PR DESCRIPTION
## Why

`default_ttl = 7200` is what let a bad homepage response outlive the good one. The
site-side fix for the *cause* landed separately in
[TellersTechOrg/tellerstech-website#1172](https://github.com/TellersTechOrg/tellerstech-website/pull/1172),
which identified it conclusively: nothing was ever corrupt, and CloudFront was caching a
**different, valid response** under the homepage's key. Wordfence answers
`?wordfence_syncAttackData=…` with `Content-Type: text/javascript`, a ~31-byte body and
no `cache-control`; that parameter isn't in this policy's ten-parameter whitelist, so it
was stripped and the reply was filed under bare `/`. 113 such requests in four days, all
from real visitors' browsers via CloudFront.

That PR stops it at the origin with an mu-plugin that sends `no-store` for requests
carrying a parameter absent from the cache key, and it names this TTL as the one
remaining judgement call:

> Remaining judgement call, not in this PR: the policy's **7200s default TTL** in
> `wbat/wbat-terraform`. It does not cause poisoning, but lowering it would cap how long
> any future variant lasts.

This PR is that change.

## What changed

`default_ttl` on the `wordpress` and `podcast` cache policies: `7200` → `60`.

## Why it's worth doing even though the cause is fixed

The guard handles the parameter we now know about. This bounds the blast radius of the
**next** one. The fault was live seven times over three weeks before anyone identified
it, and on the last day it recurred twice within an hour, the second time ~35 minutes
after an automated repair. With `default_ttl` at 60s, a comparable episode expires on its
own in about a minute instead of riding the cache for up to two hours.

Concretely, from the incident record — the poisoned object outlived the healthy one
beside it by ~24x purely by omitting a header:

| Variant | Bytes | `cache-control` | Age reached |
|---|---|---|---|
| gzip (poisoned) | 20 | *none* | 5072s |
| identity (healthy) | 153969 | `public, max-age=300` | 29s |

## Why this is safe for healthy traffic

`default_ttl` applies **only** when the origin sends no `cache-control`. Every healthy
page on this distribution sets its own, verified live:

| Path | `cache-control` |
|---|---|
| `/` | `public, max-age=300, stale-while-revalidate=3600` |
| `/ship-it-weekly-podcast/`, `/on-call-brief-news/` | `public, max-age=300, stale-while-revalidate=3600` |
| `/advisory/`, `/labs/`, `/contact-us/`, `/awards/`, `/book/` | `public, max-age=86400, stale-while-revalidate=604800` |

Those lifetimes don't change. The only responses affected are ones arriving with no
`cache-control` — which is the fault's signature, and for those a one-minute cache is the
point. `min_ttl` stays `0`, which is also what lets the new origin guard's `no-store` be
honoured.

`static_assets` is deliberately untouched: its `min_ttl` is 1 day and this has only ever
hit HTML.

## Test plan

- [x] `terraform fmt -check` clean
- [x] `terraform validate` passes
- [x] Plan is **0 to add, 2 to change, 0 to destroy** — both cache policies in place, no
      distribution replacement
- [ ] After apply, confirm a healthy page still reports its own `max-age` and normal
      `x-cache: Hit` behaviour
- [ ] If a comparable fault ever appears, confirm `age` on the bad variant never exceeds ~60s

Background: `docs/empty-gzip-page-cache.md` in the tellerstech-website repo, updated in
[#1173](https://github.com/TellersTechOrg/tellerstech-website/pull/1173).