### PR TITLE
fix(cloudfront): pin newsletter tracking hops to CachingDisabled, correct the order/orderby cache-key rationale

### DIFF
--- a/aws/global/cloudfront/tellerstech-website.tf
+++ b/aws/global/cloudfront/tellerstech-website.tf
@@ -58,10 +58,19 @@ resource "aws_cloudfront_cache_policy" "wordpress" {
           "preview",
           "preview_id",
           "preview_nonce",
-          # order / orderby deliberately omitted: the archives ignore WordPress's
-          # orderby (they render off siw_paged / ocb_paged), and the front page --
-          # the one place they changed output -- is pinned at the origin by
-          # tt_landing_pin_front_page().
+          # WP public query vars that reorder SEARCH results. They do NOT affect
+          # the archives (those render off siw_paged / ocb_paged) and no longer
+          # affect the front page (pinned at the origin by
+          # tt_landing_pin_front_page), but /?s=<term> still honours both --
+          # verified 2026-08-22 that ?s=ship&orderby=title, ?s=ship&order=asc and
+          # ?s=ship&orderby=title&order=desc each return a different result
+          # order. `s` is keyed and the origin request policy forwards every
+          # query string, so dropping these would collapse /?s=ship&orderby=title
+          # onto the same object as /?s=ship and let whichever missed first serve
+          # its ordering to the other. Reclaiming these two slots requires the
+          # origin to normalise order/orderby for search as well.
+          "order",
+          "orderby",
           # Ship It Weekly episode-category facets, rendered server-side. Needed
           # on this policy too (not just Podcast-CachePolicy): the podcast
           # behaviors match the exact paths /ship-it-weekly-podcast/[host|media-kit]/,
@@ -127,7 +136,10 @@ resource "aws_cloudfront_cache_policy" "podcast" {
           "preview",
           "preview_id",
           "preview_nonce",
-          # order / orderby dropped -- see WordPress-CachePolicy above.
+          # See WordPress-CachePolicy: kept because they reorder search results
+          # and the origin forwards them.
+          "order",
+          "orderby",
           # Episode-category facets on the SIW hub. Without this in the cache
           # key the page cache is effectively keyed on path alone, so every
           # ?category= URL serves one cached copy of the unfiltered episode list.

--- a/aws/global/cloudfront/tellerstech-website.tf
+++ b/aws/global/cloudfront/tellerstech-website.tf
@@ -58,12 +58,10 @@ resource "aws_cloudfront_cache_policy" "wordpress" {
           "preview",
           "preview_id",
           "preview_nonce",
-          # WP public query vars that reorder archive/search listings. Kept even
-          # though this site rarely links them: origin still forwards them, so
-          # omitting them from the cache key would let ?orderby=title&order=asc
-          # poison the clean archive entry.
-          "order",
-          "orderby",
+          # order / orderby deliberately omitted: the archives ignore WordPress's
+          # orderby (they render off siw_paged / ocb_paged), and the front page --
+          # the one place they changed output -- is pinned at the origin by
+          # tt_landing_pin_front_page().
           # Ship It Weekly episode-category facets, rendered server-side. Needed
           # on this policy too (not just Podcast-CachePolicy): the podcast
           # behaviors match the exact paths /ship-it-weekly-podcast/[host|media-kit]/,
@@ -129,9 +127,7 @@ resource "aws_cloudfront_cache_policy" "podcast" {
           "preview",
           "preview_id",
           "preview_nonce",
-          # See WordPress-CachePolicy: kept because origin forwards them.
-          "order",
-          "orderby",
+          # order / orderby dropped -- see WordPress-CachePolicy above.
           # Episode-category facets on the SIW hub. Without this in the cache
           # key the page cache is effectively keyed on path alone, so every
           # ?category= URL serves one cached copy of the unfiltered episode list.

--- a/aws/global/cloudfront/tellerstech-website.tf
+++ b/aws/global/cloudfront/tellerstech-website.tf
@@ -318,6 +318,129 @@ resource "aws_cloudfront_distribution" "tellerstech_website" {
     cache_policy_id        = "658327ea-f89d-4fab-a63d-7e88639e58f6" # AWS Managed CachingOptimized
   }
 
+  # Newsletter tracking hops - never cacheable. These are per-recipient endpoints
+  # whose distinguishing params (w, u, sig, token) are NOT in the cache key, so a
+  # cacheable response on one of these paths gets replayed for every other link
+  # the same subscriber clicks. That happened in production: one cached 302 sent
+  # every link in an email to the same wrong page, and none of those clicks
+  # reached origin to be logged. The origin already sends "private, no-store"
+  # (tt_sub_send_no_store_headers), so pinning CachingDisabled here is
+  # defence-in-depth — it stops one PHP branch forgetting the header from
+  # becoming a cache-poisoning bug again.
+  #
+  # An ordered_cache_behavior inherits NOTHING from default_cache_behavior, so
+  # all five below must carry three things that are easy to leave off:
+  #
+  #   1. origin_request_policy_id. The click/open analytics read User-Agent and
+  #      CloudFront-Viewer-Country / -Region / -City off the origin request.
+  #      Without it every click logs as "Desktop / Other / Other" with no geo.
+  #
+  #   2. The viewer-response rewrite_origin_location association. All five paths
+  #      emit a Location header, and they only get the origin-host rewrite today
+  #      by falling through to the default behavior. Without it an nginx-level
+  #      absolute redirect hands subscribers an origin.tellerstech.com URL, which
+  #      fails the CloudFront origin gate. The viewer-REQUEST function is
+  #      deliberately not carried over: it only handles /xmlrpc.php and
+  #      /wp-admin, neither of which can match these patterns.
+  #
+  #   3. The trailing slash in each pattern. "*" matches "/" in CloudFront path
+  #      patterns, so "/*-open*" would also match episode slugs like
+  #      /ship-it-weekly-podcast/...-openai-... and silently drop them out of the
+  #      page cache.
+  #
+  # Wildcard collision re-checked against the live sitemap on 2026-08-22: 195
+  # indexed URLs, none ending in -click, -open, -confirm or -unsubscribe. If one
+  # ever appears, swap that single pattern for the three explicit list paths
+  # (/ocb-click/, /siw-click/, /cd-click/) — the behavior quota has room for one
+  # such expansion, not four.
+
+  # Click tracking. Full method list for symmetry with the other form-capable
+  # WordPress behaviors.
+  ordered_cache_behavior {
+    path_pattern             = "/*-click/"
+    allowed_methods          = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods           = ["GET", "HEAD"]
+    target_origin_id         = "wordpress-origin"
+    viewer_protocol_policy   = "redirect-to-https"
+    compress                 = true
+    cache_policy_id          = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" # AWS Managed CachingDisabled
+    origin_request_policy_id = aws_cloudfront_origin_request_policy.wordpress.id
+
+    function_association {
+      event_type   = "viewer-response"
+      function_arn = aws_cloudfront_function.rewrite_origin_location.arn
+    }
+  }
+
+  # Open tracking (pixel) - only ever fetched by a mail client.
+  ordered_cache_behavior {
+    path_pattern             = "/*-open/"
+    allowed_methods          = ["GET", "HEAD"]
+    cached_methods           = ["GET", "HEAD"]
+    target_origin_id         = "wordpress-origin"
+    viewer_protocol_policy   = "redirect-to-https"
+    compress                 = true
+    cache_policy_id          = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" # AWS Managed CachingDisabled
+    origin_request_policy_id = aws_cloudfront_origin_request_policy.wordpress.id
+
+    function_association {
+      event_type   = "viewer-response"
+      function_arn = aws_cloudfront_function.rewrite_origin_location.arn
+    }
+  }
+
+  # Double opt-in confirmation. Full method list, as for /*-click/.
+  ordered_cache_behavior {
+    path_pattern             = "/*-confirm/"
+    allowed_methods          = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods           = ["GET", "HEAD"]
+    target_origin_id         = "wordpress-origin"
+    viewer_protocol_policy   = "redirect-to-https"
+    compress                 = true
+    cache_policy_id          = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" # AWS Managed CachingDisabled
+    origin_request_policy_id = aws_cloudfront_origin_request_policy.wordpress.id
+
+    function_association {
+      event_type   = "viewer-response"
+      function_arn = aws_cloudfront_function.rewrite_origin_location.arn
+    }
+  }
+
+  # Unsubscribe. The full method list is required here, not cosmetic: RFC 8058
+  # one-click unsubscribe POSTs to this path.
+  ordered_cache_behavior {
+    path_pattern             = "/*-unsubscribe/"
+    allowed_methods          = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods           = ["GET", "HEAD"]
+    target_origin_id         = "wordpress-origin"
+    viewer_protocol_policy   = "redirect-to-https"
+    compress                 = true
+    cache_policy_id          = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" # AWS Managed CachingDisabled
+    origin_request_policy_id = aws_cloudfront_origin_request_policy.wordpress.id
+
+    function_association {
+      event_type   = "viewer-response"
+      function_arn = aws_cloudfront_function.rewrite_origin_location.arn
+    }
+  }
+
+  # Outbound link shortener - same per-recipient replay problem.
+  ordered_cache_behavior {
+    path_pattern             = "/go/*"
+    allowed_methods          = ["GET", "HEAD"]
+    cached_methods           = ["GET", "HEAD"]
+    target_origin_id         = "wordpress-origin"
+    viewer_protocol_policy   = "redirect-to-https"
+    compress                 = true
+    cache_policy_id          = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" # AWS Managed CachingDisabled
+    origin_request_policy_id = aws_cloudfront_origin_request_policy.wordpress.id
+
+    function_association {
+      event_type   = "viewer-response"
+      function_arn = aws_cloudfront_function.rewrite_origin_location.arn
+    }
+  }
+
   # Ship It Weekly hub page - capped at 12 hours (Podcast-CachePolicy) so the
   # latest-episodes list does not go stale. EXACT match: the pattern has no "*",
   # so it matches only "/ship-it-weekly-podcast/" and NOT the episode pages


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Changes to the `www.tellerstech.com` distribution in `aws/global/cloudfront/tellerstech-website.tf`. Applies through HCP Terraform (`wbat-terraform-aws`) on merge — no local apply, and nothing was touched with the `aws cloudfront` CLI.

> **Scope changed after review.** This PR originally also dropped `order` / `orderby` from the cache-key whitelist. Codex flagged that as unsafe, the flag was correct, and the change is withdrawn in `cca6bdb`. The cache key is now byte-identical to `main`; only the comments explaining it changed. Details in the second section.

## 1. Pin the tracking hops to CachingDisabled (the actual change)

Five new `ordered_cache_behavior` blocks, placed immediately after `/errors/*` and before the Ship It Weekly hub behavior, shaped like the existing `/wp-json/*` behavior:

| Pattern | `allowed_methods` |
| --- | --- |
| `/*-click/` | DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT |
| `/*-open/` | GET, HEAD |
| `/*-confirm/` | DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT |
| `/*-unsubscribe/` | DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT |
| `/go/*` | GET, HEAD |

The full method list is required on `-unsubscribe` because RFC 8058 one-click unsubscribe POSTs there; `-click` and `-confirm` take it for symmetry with the other form-capable WordPress behaviors.

These are per-recipient hops whose distinguishing params (`w`, `u`, `sig`, `token`) are not in the cache key, so a cacheable response on those paths gets replayed for every other link the same subscriber clicks. That happened in production: one cached 302 sent every link in an email to the same wrong page, and none of those clicks reached origin to be logged. The origin already sends `private, no-store` (`tt_sub_send_no_store_headers`), so this is defence-in-depth — it stops one PHP branch forgetting the header from becoming a cache-poisoning bug again.

An `ordered_cache_behavior` inherits nothing from `default_cache_behavior`, so all five also carry:

- **`origin_request_policy_id`** — the click/open analytics read `User-Agent` and `CloudFront-Viewer-Country` / `-Region` / `-City` off the origin request. Without it every click logs as "Desktop / Other / Other" with no geo.
- **the viewer-response `rewrite_origin_location` association** — all five paths emit a `Location` header and today only get the origin-host rewrite by falling through to the default behavior. Without it an nginx-level absolute redirect hands subscribers an `origin.tellerstech.com` URL, which fails the CloudFront origin gate. The viewer-**request** function is deliberately not carried over; it only handles `/xmlrpc.php` and `/wp-admin`, neither of which can match these patterns.
- **the trailing slash in each pattern** — `*` matches `/` in CloudFront path patterns, so `/*-open*` would also match episode slugs like `/ship-it-weekly-podcast/...-openai-...` and silently drop them out of the page cache.

Wildcard collision re-checked against the live sitemap on 2026-08-22: 195 indexed URLs, none ending in `-click`, `-open`, `-confirm` or `-unsubscribe`. If one ever appears, swap that single pattern for the three explicit list paths (`/ocb-click/`, `/siw-click/`, `/cd-click/`) — the behavior quota has room for one such expansion, not four.

## 2. `order` / `orderby` stay in the cache key — comments corrected

The original plan was to drop both from `aws_cloudfront_cache_policy.wordpress` and `aws_cloudfront_cache_policy.podcast`, on the grounds that the archives ignore WordPress's `orderby` and the front page is now pinned by `tt_landing_pin_front_page`. Codex pointed out that this reasoning never covered **search**, and that is right.

Re-verified against the live site on 2026-08-22, normalising the three per-render nonces (`wordfence_syncAttackData`, the subscribe-form id, and the W3TC `Served from` timestamp — without that normalisation every page looks like it differs):

| URL | `?orderby=title&order=asc` |
| --- | --- |
| `/` | identical (pinned) |
| `/ship-it-weekly-podcast/` | identical |
| `/ship-it-weekly-podcast/page/2/` | identical |
| `/on-call-brief-news/archive/` | identical |
| `/?s=ship` | **reordered** |
| `/?s=terraform` | **reordered** |

So the archive and front-page half of the premise holds, but search does not. `/?s=ship&orderby=title&order=asc` returns an alphabetical result set (AI…, Amazon…, AWS…, Azure…, CISA…, Cloudflare…) against the default relevance ordering.

Both params matter independently, so neither can be dropped on its own:

- `?s=ship&order=asc` differs from `?s=ship`
- `?s=ship&orderby=title&order=desc` differs from the same URL with `order=asc`

`s` is in the whitelist and the origin request policy forwards every query string, so dropping these would have collapsed `/?s=ship&orderby=title` onto the same cached object as `/?s=ship`, letting whichever variant missed first serve its ordering to every subsequent search. CloudFront can't split this out by behavior either — search lives at `/` — so the cache key is the only lever available in this repo.

Both whitelists therefore stay at 10 entries, unchanged from `main`. What this PR does keep is the corrected justification: the old comment claimed these were needed to stop `?orderby=title&order=asc` poisoning the clean **archive** entry, which is not true and would have sent the next reader down the same wrong path. The replacement names search as the real reason, records the verification, and states the precondition for reclaiming the two slots later — the origin normalising `order`/`orderby` for search, the way `tt_landing_pin_front_page` did for the front page.

`git diff main` shows no added or removed whitelist entries.

## Verification

Both CI gates from `terraform_ci.yml`, run locally on Terraform 1.15.7 (the `.terraform-version` pin) with the real AWS provider:

- `terraform fmt -recursive -check` — clean at the repo root
- `cd aws && terraform init -backend=false && terraform validate` — `Success! The configuration is valid.`
- `grep -c '^  ordered_cache_behavior {' aws/global/cloudfront/tellerstech-website.tf` → `22` (was 17, default quota 25)

No Infracost delta expected — cache behaviors are free. The local `h1:` hash that `terraform init` appends to `aws/.terraform.lock.hcl` was reverted and is not part of this PR.

## After the apply

Distribution deploys take a few minutes to propagate. Two different links, same subscriber id — both must show `no-store` and `Miss from cloudfront`:

```
S=$RANDOM$RANDOM
for w in alpha beta; do
  curl -sS -o /dev/null -D - \
    "https://www.tellerstech.com/siw-click/?s=$S&w=$w&u=aHR0cHM6Ly9leGFtcGxlLmNvbQ&sig=$(printf 'a%.0s' {1..64})" \
    | grep -iE '^(location|cache-control|x-cache|age):'
  sleep 2
done
```

A "Hit from cloudfront" on the second `/siw-click/` probe means the behavior is not matching — check pattern order against `/errors/*`.

Then confirm `/go/guardsquare` still 302s, and that a real email click still lands in the SIW → Click Log admin screen. That last one is what proves the origin request policy survived.

The `?orderby=` cache-key probe from the original description no longer applies, since that change is withdrawn.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a029e2-fc74-728f-8a15-9b384dcdeec6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a029e2-fc74-728f-8a15-9b384dcdeec6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

