### PR TITLE
fix(check-vhost): use port 80 as the regression signal so the check can actually pass

### DIFF
--- a/aws/docs/check-vhost-listeners.sh
+++ b/aws/docs/check-vhost-listeners.sh
@@ -12,6 +12,15 @@
 #        ./check-vhost-listeners.sh --ip 44.214.133.234 iots.com lmgt.com
 #        ./check-vhost-listeners.sh --json --ports 80,443 tellerstech.com iots.com
 #        ./check-vhost-listeners.sh --acme iots.com
+#        ./check-vhost-listeners.sh --strict-tls --ports 80,443 iots.com
+#
+# Port 80 is the authoritative regression signal: the catch-all regression breaks plain
+# HTTP as well as TLS, so a domain whose :80 vhost answers correctly is bound to the
+# arrival address. A :443 catch-all on such a domain means only that no HTTPS vhost or
+# certificate exists for it, which is a normal state for parked domains. That is reported
+# as NO-TLS (a warning) rather than a failure, so this exits 0 on a healthy host instead of
+# crying wolf and masking a real recurrence. Pass --strict-tls to fail on those too, and
+# note the inference needs both ports (--ports 80,443); checking :443 alone stays strict.
 #
 # Exit status: 0 = every domain matched its own vhost, 1 = at least one hit the catch-all.
 
@@ -27,12 +36,13 @@ PORTS=(443)
 JSON=0
 CHECK_ACME=0
 ALLOWLIST=""
+STRICT_TLS=0
 
 need_arg() {
   local opt="$1"
   if [ $# -lt 2 ] || [ -z "${2}" ] || [[ "${2}" == -* ]]; then
     echo "ERROR: ${opt} requires a value" >&2
-    sed -n '2,16p' "$0" >&2
+    sed -n '2,25p' "$0" >&2
     exit 2
   fi
 }
@@ -62,8 +72,12 @@ while [ $# -gt 0 ]; do
       ALLOWLIST="$2"
       shift 2
       ;;
+    --strict-tls)
+      STRICT_TLS=1
+      shift
+      ;;
     -h | --help)
-      sed -n '2,16p' "$0"
+      sed -n '2,25p' "$0"
       exit 0
       ;;
     *)
@@ -111,7 +125,24 @@ if [ "$JSON" -eq 0 ]; then
 fi
 
 failed=0
+warned=0
 json_items=()
+
+# Evaluate :80 before :443 so a domain's plain-HTTP result is known when judging TLS.
+CHECKS_PORT_80=0
+for _p in "${PORTS[@]}"; do
+  [ "$_p" = "80" ] && CHECKS_PORT_80=1
+done
+if [ "$CHECKS_PORT_80" -eq 1 ]; then
+  ordered=(80)
+  for _p in "${PORTS[@]}"; do
+    [ "$_p" != "80" ] && ordered+=("$_p")
+  done
+  PORTS=("${ordered[@]}")
+fi
+
+# Set per domain by check_one when :80 matched the domain's own vhost.
+port80_ok=0
 
 is_allowlisted() {
   local d="$1" a
@@ -158,6 +189,8 @@ check_one() {
   local d="$1" port="$2"
   local cert_cn="-" code body verdict catchall_hdr url resolve
   local tmp pem cert_ok=0
+  # Snapshot so we can tell whether *this* check failed, not an earlier domain.
+  local failed_before="$failed"
   tmp="$(mktemp)"
 
   if [ "$port" = "443" ]; then
@@ -219,6 +252,21 @@ check_one() {
     verdict="ok"
   fi
 
+  # Downgrade a TLS-only miss to a warning when plain HTTP already proved this domain's
+  # vhost is bound to the arrival address. The regression breaks :80 too, so :80 passing
+  # means the listen config is right and only a cert/HTTPS vhost is absent.
+  if [ "$port" = "443" ] && [ "$failed_before" -eq 0 ] && [ "$failed" -eq 1 ] \
+    && [ "$STRICT_TLS" -eq 0 ] && [ "$CHECKS_PORT_80" -eq 1 ] && [ "$port80_ok" -eq 1 ]; then
+    verdict="NO-TLS (no HTTPS vhost for this domain; :80 ok)"
+    failed="$failed_before"
+    warned=$((warned + 1))
+  fi
+
+  # Remember the plain-HTTP outcome for the :443 judgement on this same domain.
+  if [ "$port" = "80" ]; then
+    if [ "$verdict" = "ok" ]; then port80_ok=1; else port80_ok=0; fi
+  fi
+
   if [ "$CHECK_ACME" -eq 1 ]; then
     local acme_code acme_body
     acme_code=$(curl -sk --max-time 15 -o /dev/null -w '%{http_code}' \
@@ -245,13 +293,14 @@ check_one() {
 }
 
 for d in "${DOMAINS[@]}"; do
+  port80_ok=0
   for port in "${PORTS[@]}"; do
     check_one "$d" "$port"
   done
 done
 
 if [ "$JSON" -eq 1 ]; then
-  printf '{"origin_ip":"%s","failed":%s,"results":[' "$SERVER_IP" "$failed"
+  printf '{"origin_ip":"%s","failed":%s,"warnings":%s,"results":[' "$SERVER_IP" "$failed" "$warned"
   i=0
   for item in "${json_items[@]}"; do
     [ "$i" -gt 0 ] && printf ','
@@ -277,6 +326,13 @@ EOF
 fi
 
 if [ "$JSON" -eq 0 ]; then
-  echo "PASS: every domain matched its own vhost with a domain-appropriate certificate."
+  if [ "$warned" -gt 0 ]; then
+    echo "PASS: every domain is bound to the arrival address (:80 verified)."
+    echo "NOTE: ${warned} domain(s) have no HTTPS vhost or certificate (NO-TLS above)."
+    echo "      That is expected for parked domains and is not the catch-all regression."
+    echo "      Use --strict-tls to treat those as failures instead."
+  else
+    echo "PASS: every domain matched its own vhost with a domain-appropriate certificate."
+  fi
 fi
 exit 0

--- a/aws/docs/check-vhost-listeners.sh
+++ b/aws/docs/check-vhost-listeners.sh
@@ -189,8 +189,9 @@ check_one() {
   local d="$1" port="$2"
   local cert_cn="-" code body verdict catchall_hdr url resolve
   local tmp pem cert_ok=0
-  # Snapshot so we can tell whether *this* check failed, not an earlier domain.
-  local failed_before="$failed"
+  # Per-probe verdict flag, aggregated into the global `failed` at the end. Using a local
+  # keeps each probe's classification independent of whether an earlier domain failed.
+  local probe_failed=0
   tmp="$(mktemp)"
 
   if [ "$port" = "443" ]; then
@@ -234,20 +235,25 @@ check_one() {
     verdict="ok (allowlisted)"
   elif [ -n "$catchall_hdr" ]; then
     verdict="CATCH-ALL (X-DA-Catchall=${catchall_hdr})"
-    failed=1
+    probe_failed=1
   elif [[ "$body" == *"$CATCHALL_BODY"* ]]; then
     # Catch-all body is a failure on its own (any port), even if the cert CN changed.
     verdict="CATCH-ALL (default page body)"
-    failed=1
+    probe_failed=1
   elif [ "$port" = "443" ] && [ "$cert_cn" = "$CATCHALL_CERT_CN" ]; then
     verdict="WRONG CERT (default vhost cert)"
-    failed=1
+    probe_failed=1
   elif [ "$port" = "443" ] && [ "$cert_cn" = "(tls failed)" ]; then
     verdict="TLS HANDSHAKE FAILED"
-    failed=1
+    probe_failed=1
   elif [ "$port" = "443" ] && [ "$cert_ok" -ne 1 ]; then
     verdict="WRONG CERT (does not cover ${d})"
-    failed=1
+    probe_failed=1
+  elif [ "$code" = "000" ]; then
+    # Checked after the TLS-specific cases so a handshake failure keeps its own verdict.
+    # Never report a dead probe as ok: it proves nothing about vhost binding.
+    verdict="NO HTTP RESPONSE (connect/timeout)"
+    probe_failed=1
   else
     verdict="ok"
   fi
@@ -255,16 +261,25 @@ check_one() {
   # Downgrade a TLS-only miss to a warning when plain HTTP already proved this domain's
   # vhost is bound to the arrival address. The regression breaks :80 too, so :80 passing
   # means the listen config is right and only a cert/HTTPS vhost is absent.
-  if [ "$port" = "443" ] && [ "$failed_before" -eq 0 ] && [ "$failed" -eq 1 ] \
+  # Keyed on this probe's own result, not the global aggregate, so an earlier domain's
+  # failure cannot change how later domains are classified.
+  if [ "$port" = "443" ] && [ "$probe_failed" -eq 1 ] \
     && [ "$STRICT_TLS" -eq 0 ] && [ "$CHECKS_PORT_80" -eq 1 ] && [ "$port80_ok" -eq 1 ]; then
     verdict="NO-TLS (no HTTPS vhost for this domain; :80 ok)"
-    failed="$failed_before"
+    probe_failed=0
     warned=$((warned + 1))
   fi
 
-  # Remember the plain-HTTP outcome for the :443 judgement on this same domain.
+  # Remember the plain-HTTP outcome for the :443 judgement on this same domain. Require a
+  # real HTTP status as well as an ok verdict: a timed-out or refused :80 probe is not
+  # evidence that the domain reached its own vhost. "ok (allowlisted)" is excluded too,
+  # since an allowlisted host is expected to land on the catch-all.
   if [ "$port" = "80" ]; then
-    if [ "$verdict" = "ok" ]; then port80_ok=1; else port80_ok=0; fi
+    if [ "$verdict" = "ok" ] && [[ "$code" =~ ^[1-5][0-9][0-9]$ ]]; then
+      port80_ok=1
+    else
+      port80_ok=0
+    fi
   fi
 
   if [ "$CHECK_ACME" -eq 1 ]; then
@@ -278,18 +293,22 @@ check_one() {
       --resolve "${d}:80:${SERVER_IP}" 2>/dev/null | head -c 200 || true)
     if [[ "$acme_body" == *"$CATCHALL_BODY"* ]]; then
       verdict="${verdict}; ACME->CATCH-ALL"
-      failed=1
+      probe_failed=1
     else
       verdict="${verdict}; ACME_HTTP=${acme_code}"
     fi
   fi
 
+  # Fold this probe's outcome into the run-wide exit status.
+  [ "$probe_failed" -eq 1 ] && failed=1
+
   if [ "$JSON" -eq 1 ]; then
-    json_items+=("$(printf '{"port":%s,"host":"%s","cert_cn":"%s","http":"%s","verdict":"%s","catchall_header":"%s"}' \
-      "$port" "$d" "$cert_cn" "$code" "$verdict" "$catchall_hdr")")
+    json_items+=("$(printf '{"port":%s,"host":"%s","cert_cn":"%s","http":"%s","verdict":"%s","catchall_header":"%s","failed":%s}' \
+      "$port" "$d" "$cert_cn" "$code" "$verdict" "$catchall_hdr" "$probe_failed")")
   else
     printf '%-8s %-32s %-30s %-8s %s\n' "$port" "$d" "$cert_cn" "$code" "$verdict"
   fi
+  return 0
 }
 
 for d in "${DOMAINS[@]}"; do

--- a/aws/docs/cloudfront-tellerstech-502-troubleshooting.md
+++ b/aws/docs/cloudfront-tellerstech-502-troubleshooting.md
@@ -113,8 +113,8 @@ Ops docs and scripts for the WordPress origin gate live in **TellersTechOrg/tell
 | Origin HTTPS      | Terraform: `origin_protocol_policy = "https-only"`           |
 | Secret header     | TFC `cloudfront_origin_secret` = CF header = wp-config = cust_nginx → mismatch is **403**, not 502 |
 | DNS for origin    | BIND / external DNS → must point to origin server             |
-| SSL for origin    | Server: name/SAN covering `origin.tellerstech.com`; loopback listens required (**502** if wrong) |
-| Nginx vhost       | DA + `fix-nginx-loopback-listeners.sh`; parent cust_nginx gate |
+| SSL for origin    | Server: name/SAN covering `origin.tellerstech.com`; arrival-address listens required (**502** if wrong) |
+| Nginx vhost       | DA **Linked IP** (arrival private IP, Apache only, applied to all domains) + parent cust_nginx gate. **Never** per-domain `listen` injection — see [nginx-vhost-catchall-regression.md](nginx-vhost-catchall-regression.md) |
 | Error HTML (www)  | Terraform: S3 + OAC; `custom_error_response` for **5xx only** → `/errors/503.html` |
 
 For **502**, fix the first failing DNS/TLS/reachability check. For **403**, align the secret gate.

--- a/aws/docs/da-vhost-listen-change-window.md
+++ b/aws/docs/da-vhost-listen-change-window.md
@@ -164,7 +164,15 @@ nginx -t && systemctl reload nginx
 /usr/local/sbin/nginx-vhost-listen-invariant.sh --arrival 172.30.0.71
 ./aws/docs/check-vhost-listeners.sh --ports 80,443 --acme \
   tellerstech.com origin.tellerstech.com iots.com lmgt.com
+
+# Full inventory sweep (on-box enumerates /etc/virtual/domainowners):
+./aws/docs/check-vhost-listeners.sh --ports 80,443
 ```
+
+Expect **exit 0**. `NO-TLS` lines are warnings, not failures: those domains are bound to the
+arrival address (proved on `:80`) and merely have no HTTPS vhost or certificate, which is
+normal for parked domains. A `CATCH-ALL` on `:80` is the real regression and fails the run.
+Do not "fix" the run by allowlisting domains until you have confirmed `:80` passes for them.
 
 Confirm `www.tellerstech.com` still 200 through CloudFront and
 `origin.tellerstech.com` still 403 without the secret header.

--- a/aws/docs/nginx-vhost-catchall-regression.md
+++ b/aws/docs/nginx-vhost-catchall-regression.md
@@ -141,10 +141,28 @@ The per-domain `fix-nginx-loopback-listeners.sh` path is **retired** (cron disab
 ## Verification
 
 Use [`check-vhost-listeners.sh`](check-vhost-listeners.sh) to confirm every hosted domain is
-matched to its own vhost, from outside the VPC:
+matched to its own vhost, from outside the VPC. Always pass **both ports** — the regression
+breaks plain HTTP as well as TLS, and `:80` is what makes the result unambiguous:
 
 ```bash
-./check-vhost-listeners.sh tellerstech.com iots.com lmgt.com wbat.net
+./check-vhost-listeners.sh --ip <eip> --ports 80,443 \
+  tellerstech.com iots.com lmgt.com wbat.net
 ```
 
-Any domain reported as `CATCH-ALL` is unreachable on its own vhost and has no valid SSL.
+On-box, run it with no domains to sweep the real inventory from `/etc/virtual/domainowners`.
+
+Reading the verdicts:
+
+- **`CATCH-ALL` on `:80`** — the real regression. That domain's vhost is not bound to the
+  arrival address. Fix the Linked IP server-wide; never patch the single domain.
+- **`NO-TLS` on `:443` while `:80` is `ok`** — not the regression. The vhost is bound
+  correctly and the domain simply has no HTTPS vhost or certificate, which is the normal
+  state for parked domains. This is a warning and does not fail the run.
+- **`WRONG CERT` / `TLS HANDSHAKE FAILED`** on a domain that is supposed to serve HTTPS —
+  a certificate problem to chase separately from vhost binding.
+
+This split matters: roughly 40 of the ~91 domains on this host have no TLS configured, so
+failing on those would make the check exit non-zero permanently and hide a genuine
+recurrence. Pass `--strict-tls` when you deliberately want every domain to serve HTTPS, and
+note that checking `:443` alone stays strict because there is no `:80` evidence to reason
+from.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

The vhost-listen work from #95–#100 is deployed and working. I verified it independently from outside the VPC: all 91 hosted domains answer from their own vhost on port 80, `iots.com` and `lmgt.com` renewed certificates successfully on Aug 5 (valid to Nov 3), the `X-DA-Catchall: 1` marker is live, `www.tellerstech.com` returns 200 through CloudFront, and the origin gate still returns 403 without the secret header.

But sweeping the **full** inventory rather than the four-domain sample exposed a problem with the checker:

```
exit=1 ... 40 failures on a healthy host
443  tellerphoto.com       server.wbat.net  200  CATCH-ALL (X-DA-Catchall=1)
443  marketinginasnap.com  server.wbat.net  200  CATCH-ALL (X-DA-Catchall=1)
...
```

Roughly 40 of the 91 domains are parked with no HTTPS vhost or certificate, so a `:443` connection legitimately lands on the catch-all. Every one was scored as a hard failure. **A check that can never pass is worse than no check**, because a genuine recurrence hides among the standing failures — precisely the alert-fatigue mode this tooling exists to prevent. It also made the change-window runbook's "expect exit 0" criterion impossible to satisfy.

I confirmed these are pre-existing and not residual breakage using the committed Jul-26 fixture: those domains have only **one** `server_name` block (HTTP only), so TLS has nowhere to land. `boyfriend-track.com` has two blocks and correctly returns a real 404 from its own vhost.

## What changed

The catch-all regression breaks **plain HTTP as well as TLS** — one of the three original diagnostic facts. So `:80` is the authoritative signal:

- `:80` proves a domain is bound to the arrival address. A `:443` catch-all on such a domain means only that no HTTPS vhost exists, now reported as `NO-TLS` (warning, run stays green).
- `CATCH-ALL` on `:80` still fails hard — that is the real regression.
- `:80` is evaluated before `:443` so the evidence exists when judging TLS.
- `:443`-only runs stay strict, since there is no `:80` evidence to reason from.
- New `--strict-tls` demands HTTPS on every domain.
- JSON gains `warnings` plus a per-probe `failed` value.

Also fixed a documentation contradiction: the 502 runbook body warns that per-domain `listen` injection caused the outage and that `fix-nginx-loopback-listeners.sh` is retired, but its **summary table still listed that script** as the mechanism for the nginx vhost row. An operator skimming to the summary would reach for the exact script that breaks every other domain on the host.

## Codex review fixes (0347312)

Both findings were real bugs in the evidence logic that my own tests missed, and both are fixed:

**P1 — dead `:80` probe licensed a TLS downgrade.** A timed-out or refused `:80` request yields curl status `000`, which fell through the verdict chain to `ok` and set the evidence flag, downgrading a genuine `:443` failure to `NO-TLS`. An entirely unreachable host scored a **false exit 0**. Added an explicit `NO HTTP RESPONSE (connect/timeout)` verdict — placed after the TLS-specific cases so a handshake failure keeps its own diagnosis — and the evidence flag now requires a real `1xx`–`5xx` status. `ok (allowlisted)` is excluded from evidence too, since an allowlisted host is expected to hit the catch-all.

**P2 — downgrade keyed on the global failure flag.** Once any domain failed, `failed` stayed `1`, so every parked domain after the first real failure was misreported as a hard `CATCH-ALL` with its warning dropped, making results depend on argument order. Replaced with a per-probe `local probe_failed`, folded into the run-wide status at the end of `check_one`.

My tests missed both because the live sweep has zero hard failures and the negative controls were single-domain runs, so neither the dead-probe nor the ordering path was exercised. Both now have explicit tests.

## Verification

Live against the production host:

| Scenario | Result |
|---|---|
| Full 91-domain sweep, both ports | **exit 0** — 142 ok, 40 NO-TLS, 0 hard failures |
| Unreachable host (`192.0.2.1`, both ports) | **exit 1** — was a false exit 0 before P1 fix |
| Parked domain after a failing domain | classified `NO-TLS` identically in both orders; failing domain still drives **exit 1** |
| Hostname with no vhost, both ports | **exit 1**, CATCH-ALL on 80 and 443 |
| `--strict-tls` on a parked domain | **exit 1** |
| `:443` only on a parked domain | **exit 1** (strict retained) |
| Healthy domain, both ports | **exit 0** |

CI-equivalent gates pass: `bash -n`, `shellcheck -S error -x -e SC1091` (also clean at `-S warning`), and the offline fixture detector proofs.

The negative controls are the important ones — a domain that fails on `:80`, and a host that answers on neither port, both still fail — so detection is preserved rather than weakened.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9f56-a7f8-7855-8a9d-05a6fedbcfe7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9f56-a7f8-7855-8a9d-05a6fedbcfe7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

