### PR TITLE
fix(da): stop the reconciler log overstating TLS coverage

### DIFF
--- a/aws/docs/nginx-vhost-catchall-regression.md
+++ b/aws/docs/nginx-vhost-catchall-regression.md
@@ -157,7 +157,12 @@ Reading the verdicts:
   arrival address. Fix the Linked IP server-wide; never patch the single domain.
 - **`NO-TLS` on `:443` while `:80` is `ok`** — not the regression. The vhost is bound
   correctly and the domain simply has no HTTPS vhost or certificate, which is the normal
-  state for parked domains. This is a warning and does not fail the run.
+  state for parked domains. This is a warning and does not fail the run. **But** a domain
+  that previously served HTTPS appearing in this list means its HTTPS block or certificate
+  was dropped. The on-box invariant will not flag that, because it only requires the arrival
+  IP on the ports each block actually *declares* — a block that no longer exists declares
+  nothing. Scan the `NO-TLS` list for domains that are supposed to serve TLS; that is the
+  one failure mode the reconciler cannot see.
 - **`WRONG CERT` / `TLS HANDSHAKE FAILED`** on a domain that is supposed to serve HTTPS —
   a certificate problem to chase separately from vhost binding.
 

--- a/scripts/directadmin/da_vhost_listen_reconcile.sh
+++ b/scripts/directadmin/da_vhost_listen_reconcile.sh
@@ -485,7 +485,11 @@ main() {
     drift=1
     invariant_failed=1
   else
-    log "OK nginx invariant: all server_names listen on ${arrival} :80 and :443"
+    # Scoped wording on purpose: the invariant only requires the arrival IP on the
+    # ports each server block actually declares. Domains with no HTTPS block (parked
+    # domains, ~40 here) are checked on :80 only, so claiming ":80 and :443" would
+    # overstate TLS coverage and contradict check-vhost-listeners.sh NO-TLS warnings.
+    log "OK nginx invariant: every server_name listens on ${arrival} for the ports it declares"
   fi
 
   if [[ "$drift" -eq 0 ]]; then


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Production logs from the box read:

```
2026-08-23T00:10:02-04:00 OK mode=enforce arrival=172.30.0.71 public=44.214.133.234 lan_ip=172.30.0.71
2026-08-23T00:10:03-04:00 OK nginx invariant: all server_names listen on 172.30.0.71 :80 and :443
2026-08-23T00:10:03-04:00 OK no drift
```

The invariant does not verify that claim. [`nginx_vhost_listen_invariant.sh`](scripts/directadmin/nginx_vhost_listen_invariant.sh) deliberately requires the arrival IP only on the ports each server block actually **declares**:

```
# DA emits separate server{} blocks for :80 and :443. Only require the
# arrival IP for ports this block actually declares.
```

That scoping is correct — roughly 40 of the 91 domains are parked with no HTTPS block, and demanding `:443` everywhere would fail them permanently. The script's own summary is already honest (`OK invariant: 180 server blocks cover arrival 172.30.0.87 on declared ports`). Only the reconciler's log line overstated it.

## Why it matters

**It contradicts the external checker.** `check-vhost-listeners.sh` reports 40 `NO-TLS` warnings for exactly those domains. An operator reading "all server_names listen on :80 and :443" would reasonably conclude every domain serves HTTPS and then have to work out which tool is lying — during an incident, that is wasted time pointed in the wrong direction.

**It masks the reconciler's one real blind spot.** If a domain's HTTPS block is dropped entirely (SSL disabled, certificate removed), that block declares no `:443`, so the invariant keeps passing — correctly, by its own contract. A log line asserting `:80 and :443` implies the opposite and would actively hide the regression.

## What changed

- Reworded the success log to what is actually checked: `every server_name listens on <arrival> for the ports it declares`, with a comment explaining why the narrower wording is deliberate so it does not get "helpfully" widened later.
- Documented the blind spot in [nginx-vhost-catchall-regression.md](aws/docs/nginx-vhost-catchall-regression.md): scan the `NO-TLS` list for domains that are *supposed* to serve TLS, because that is where a dropped HTTPS block surfaces and the reconciler cannot see it.

No behaviour change — logging and docs only. The `ERROR` branch was already accurate and is untouched.

## Verification

`bash -n` and `shellcheck -S error -x -e SC1091` pass on the reconciler; the offline fixture detector proofs still pass.

Separately, the log excerpt above confirms the deployed protection is healthy and behaving as designed: the arrival IP is auto-detected correctly as `172.30.0.71`, the Linked IP and `lan_ip` are right, the 10-minute `--enforce` cron is firing, and **enforce is a no-op when there is no drift** — which was an explicit design goal, so a healthy host never triggers a vhost rewrite.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9f56-a7f8-7855-8a9d-05a6fedbcfe7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9f56-a7f8-7855-8a9d-05a6fedbcfe7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

