### PR TITLE
fix(da): reject placeholder alert addresses instead of silently blackholing

### DIFF
--- a/scripts/directadmin/da_vhost_listen_reconcile.sh
+++ b/scripts/directadmin/da_vhost_listen_reconcile.sh
@@ -230,6 +230,28 @@ invariant_check() {
 rate_limited_alert() {
   local subject="$1"
   local body="$2"
+  local dest="${HEALTH_ALERT_TO}"
+  local dest_lc="${dest,,}"
+
+  # Validate the destination *before* touching the cooldown stamp. A host that cannot
+  # alert should say so on every run instead of logging once and going quiet for an
+  # hour, and it must not consume the stamp that would suppress the next real alert.
+  if [[ -z "$dest" ]]; then
+    log "ERROR alert not sent (HEALTH_ALERT_TO unset in ${CONFIG}): $subject"
+    return 0
+  fi
+  # RFC 2606 reserves these names, so they can never receive mail. Without this check a
+  # leftover install placeholder logs "OK alert mailed" while nobody is ever paged --
+  # a silent blackhole that looks healthier in the log than having no address at all.
+  if [[ "$dest_lc" =~ @([a-z0-9-]+\.)*(example\.(com|net|org)|example|invalid|test|localhost)$ ]]; then
+    log "ERROR alert not sent (HEALTH_ALERT_TO=${dest} is a reserved placeholder; set a real address in ${CONFIG}): $subject"
+    return 0
+  fi
+  if ! command -v mail >/dev/null 2>&1; then
+    log "ERROR alert not sent (no mail binary; install s-nail or mailx): $subject"
+    return 0
+  fi
+
   mkdir -p "$STATE_DIR"
   local now last
   now="$(date +%s)"
@@ -240,12 +262,8 @@ rate_limited_alert() {
     return 0
   fi
   echo "$now" >"$ALERT_STAMP"
-  if [[ -n "${HEALTH_ALERT_TO}" ]] && command -v mail >/dev/null 2>&1; then
-    printf '%s\n' "$body" | mail -s "$subject" "$HEALTH_ALERT_TO" || true
-    log "OK alert mailed to $HEALTH_ALERT_TO"
-  else
-    log "ERROR alert (no HEALTH_ALERT_TO or mail): $subject"
-  fi
+  printf '%s\n' "$body" | mail -s "$subject" "$dest" || true
+  log "OK alert mailed to $dest"
 }
 
 netmask_for_arrival() {

--- a/scripts/directadmin/vhost-listen.conf.example
+++ b/scripts/directadmin/vhost-listen.conf.example
@@ -4,6 +4,10 @@
 # Placeholders only in git — fill real values on the box.
 
 # Optional local-MTA alert destination (rate-limited by the reconciler).
+# Must be a real deliverable address. RFC 2606 reserved names (anything at
+# example.com/.net/.org, or ending in .example/.invalid/.test/.localhost) are
+# rejected and logged as ERROR, so a copy-pasted placeholder cannot masquerade
+# as working alerting. Leave empty only if you accept drift going unnoticed.
 HEALTH_ALERT_TO=""
 
 # Expected public EIP for this host (IMDS ENI selection + sanity checks).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Verifying the alert path on the primary server surfaced this. `HEALTH_ALERT_TO` was empty, and the install instructions carry `HEALTH_ALERT_TO="you@example.com"` as a fill-in-your-address placeholder — which is easy to apply verbatim. The reconciler then passed it to `mail(1)` and logged:

```
2026-08-23T00:31:56-04:00 OK alert mailed to you@example.com
```

`example.com` is [RFC 2606](https://www.rfc-editor.org/rfc/rfc2606) reserved and can never receive mail. So drift alerts went nowhere while the log claimed success — **strictly worse than leaving the value empty**, which at least logged `ERROR alert (no HEALTH_ALERT_TO or mail)` and made the gap visible. A monitoring path that reports success while delivering nothing is the failure mode this tooling exists to avoid.

## What changed

**Reject RFC 2606 reserved destinations** and log an `ERROR` naming the config file to fix:

- `example.com` / `.net` / `.org` and their subdomains (`admin@sub.example.com`)
- anything ending in `.example`, `.invalid`, `.test`, `.localhost`
- case-insensitive

**Validate the destination before touching the cooldown stamp.** Previously an unalertable host wrote the stamp, logged its `ERROR` once, then went quiet for an hour — so the one-per-hour rate limit suppressed the very message telling you alerting was broken. Worse, consuming the stamp meant that if the address were fixed within the hour, the next genuinely sendable alert could be dropped. Validation now runs on every invocation and only a real send consumes the stamp. Missing `mail` binary gets its own distinct message too, rather than being folded in with a missing address.

Also documented the constraint in [`vhost-listen.conf.example`](scripts/directadmin/vhost-listen.conf.example) so the placeholder trap is called out at the point of use.

## Verification

Exercised the detection logic across the realistic cases:

| Address | Result |
|---|---|
| *(unset)* | rejected |
| `you@example.com` | rejected |
| `You@Example.COM` | rejected (case-insensitive) |
| `ops@example.net`, `x@example.org` | rejected |
| `admin@sub.example.com` | rejected |
| `a@foo.example`, `b@host.invalid`, `c@my.test`, `d@localhost` | rejected |
| `brian@tellerstech.com`, `alerts@wbat.net` | **accepted** |
| `ops@example.company.com` | **accepted** (not a reserved suffix) |

That last row is the one worth noting — the anchoring must not reject a legitimate domain that merely contains "example".

`bash -n` and `shellcheck -S error -x -e SC1091` pass; offline fixture detector proofs still pass.

## Note on the deployed host

The live config currently has the placeholder written into it, so **alerting is effectively off until a real address is set**:

```bash
read -rp "Alert address: " ALERT_ADDR
sudo sed -i "s|^HEALTH_ALERT_TO=.*|HEALTH_ALERT_TO=\"${ALERT_ADDR}\"|" \
  /etc/da-vhost-listen/vhost-listen.conf
sudo grep '^HEALTH_ALERT_TO=' /etc/da-vhost-listen/vhost-listen.conf
```

Once this merges, a leftover placeholder will announce itself in the log rather than passing as healthy.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9f56-a7f8-7855-8a9d-05a6fedbcfe7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9f56-a7f8-7855-8a9d-05a6fedbcfe7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

