### PR TITLE
feat(da): one-command install plus drift check for vhost-listen tooling

### DIFF
--- a/scripts/directadmin/README.md
+++ b/scripts/directadmin/README.md
@@ -75,6 +75,7 @@ Known-bad fixture: [`aws/docs/fixtures/nginx-catchall-broken-2026-07-26/`](../..
 | `da-vhost-listen-boot.service` | `/etc/systemd/system/da-vhost-listen-boot.service` |
 | `user_httpd_write_post-da-vhost-listen-check.sh` | `/usr/local/directadmin/scripts/custom/user_httpd_write_post/da-vhost-listen-check.sh` (mode 700, `diradmin:diradmin`) |
 | `update_post-da-vhost-listen.sh` | append/call from `/usr/local/directadmin/scripts/custom/update_post.sh` |
+| `install_da_vhost_listen.sh` | not installed; run from the checkout to install the rows above or check them for drift |
 
 ### Install / update (from a repo checkout on the box)
 
@@ -122,6 +123,33 @@ install -m 755 scripts/directadmin/nginx_vhost_listen_invariant.sh \
   /usr/local/sbin/nginx-vhost-listen-invariant.sh
 /usr/local/sbin/da-vhost-listen-reconcile.sh --check
 ```
+
+### One-command install / drift check (preferred)
+
+**There is no deploy pipeline in this repo.** Merging a reconciler PR does not change
+what the host executes — the running copy only changes when someone re-runs `install`.
+That has already bitten: two merged PRs altered reconciler behaviour while the host kept
+executing the previous version. [`install_da_vhost_listen.sh`](install_da_vhost_listen.sh)
+makes both halves one command each:
+
+```bash
+cd /root/wbat-terraform && git pull
+
+# Report whether the installed copies match this checkout (safe, read-only).
+./scripts/directadmin/install_da_vhost_listen.sh --verify
+
+# Install or update everything, enable the boot unit, then re-verify.
+sudo ./scripts/directadmin/install_da_vhost_listen.sh --install
+```
+
+`--verify` compares each installed file against the repo by SHA-256 and reports `ok`,
+`STALE`, or `MISSING`, exiting non-zero on any drift — so "did this merge actually reach
+production?" has a definite answer. `--install` is idempotent and **never overwrites**
+`/etc/da-vhost-listen/vhost-listen.conf`, because that file holds host-specific values
+(`EXPECTED_PUBLIC_IP`, `HEALTH_ALERT_TO`); it is only created from the example when
+absent. The runtime conf is therefore presence-checked, not content-compared.
+
+Run `--verify` after any merge that touches `scripts/directadmin/`, and on both hosts.
 
 ### Per-host `vhost-listen.conf`
 

--- a/scripts/directadmin/install_da_vhost_listen.sh
+++ b/scripts/directadmin/install_da_vhost_listen.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+# Install or verify the da-vhost-listen tooling from a repo checkout.
+#
+# This repo has no deploy pipeline: merging a reconciler fix does NOT update the copy
+# running on the host. That is a real failure mode -- PRs #103 and #104 both changed
+# reconciler behaviour while the host kept executing the previous version. Run
+# --install after any merge touching these files, and --verify to detect an installed
+# copy that has drifted from the repo.
+#
+# Usage:
+#   ./install_da_vhost_listen.sh --verify        # report drift; exit 1 if stale/missing
+#   sudo ./install_da_vhost_listen.sh --install  # idempotent install/update
+#
+# --install never overwrites an existing /etc/da-vhost-listen/vhost-listen.conf, since
+# that file holds host-specific values (EXPECTED_PUBLIC_IP, HEALTH_ALERT_TO).
+#
+# Paths are overridable by environment variable so this can be exercised without root.
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+SRC_DIR="${REPO_DIR}/scripts/directadmin"
+
+SBIN_DIR="${DA_VHOST_SBIN_DIR:-/usr/local/sbin}"
+ETC_DIR="${DA_VHOST_ETC_DIR:-/etc/da-vhost-listen}"
+CRON_DIR="${DA_VHOST_CRON_DIR:-/etc/cron.d}"
+UNIT_DIR="${DA_VHOST_UNIT_DIR:-/etc/systemd/system}"
+DA_CUSTOM_DIR="${DA_VHOST_DA_CUSTOM_DIR:-/usr/local/directadmin/scripts/custom}"
+HOOK_OWNER="${DA_VHOST_HOOK_OWNER:-diradmin:diradmin}"
+
+MODE=""
+
+usage() {
+  sed -n '2,18p' "$0"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --install) MODE=install; shift ;;
+    --verify) MODE=verify; shift ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown arg: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$MODE" ]]; then
+  echo "ERROR: pass --install or --verify" >&2
+  usage >&2
+  exit 2
+fi
+
+# src|dst|mode  -- content-compared files only. The runtime conf is handled separately
+# because it is meant to diverge from the committed example.
+MANAGED=(
+  "da_vhost_listen_reconcile.sh|${SBIN_DIR}/da-vhost-listen-reconcile.sh|755"
+  "nginx_vhost_listen_invariant.sh|${SBIN_DIR}/nginx-vhost-listen-invariant.sh|755"
+  "cron.d-da-vhost-listen|${CRON_DIR}/da-vhost-listen|644"
+  "da-vhost-listen-boot.service|${UNIT_DIR}/da-vhost-listen-boot.service|644"
+  "user_httpd_write_post-da-vhost-listen-check.sh|${DA_CUSTOM_DIR}/user_httpd_write_post/da-vhost-listen-check.sh|700"
+)
+
+hash_of() { sha256sum "$1" 2>/dev/null | awk '{print $1}'; }
+
+verify() {
+  local drift=0 entry src dst mode src_h dst_h
+  printf '%-46s %s\n' "INSTALLED PATH" "STATE"
+  printf '%-46s %s\n' "--------------" "-----"
+  for entry in "${MANAGED[@]}"; do
+    IFS='|' read -r src dst mode <<<"$entry"
+    src="${SRC_DIR}/${src}"
+    if [[ ! -f "$src" ]]; then
+      printf '%-46s %s\n' "$dst" "ERROR missing in repo: $src"
+      drift=1
+      continue
+    fi
+    if [[ ! -e "$dst" ]]; then
+      printf '%-46s %s\n' "$dst" "MISSING (never installed)"
+      drift=1
+      continue
+    fi
+    src_h="$(hash_of "$src")"
+    dst_h="$(hash_of "$dst")"
+    if [[ "$src_h" != "$dst_h" ]]; then
+      printf '%-46s %s\n' "$dst" "STALE (differs from repo)"
+      drift=1
+    else
+      printf '%-46s %s\n' "$dst" "ok"
+    fi
+  done
+
+  # Presence-only: contents are host-specific by design.
+  if [[ -e "${ETC_DIR}/vhost-listen.conf" ]]; then
+    printf '%-46s %s\n' "${ETC_DIR}/vhost-listen.conf" "present (host-specific; not compared)"
+  else
+    printf '%-46s %s\n' "${ETC_DIR}/vhost-listen.conf" "MISSING (reconciler has no config)"
+    drift=1
+  fi
+
+  echo
+  if [[ "$drift" -ne 0 ]]; then
+    echo "FAIL: installed tooling does not match this checkout."
+    echo "      Run: sudo $0 --install   (after 'git pull' on the box)"
+    return 1
+  fi
+  echo "PASS: installed tooling matches this checkout."
+  return 0
+}
+
+do_install() {
+  local entry src dst mode
+  mkdir -p "$SBIN_DIR" "$ETC_DIR" "$CRON_DIR" "$UNIT_DIR" \
+    "${DA_CUSTOM_DIR}/user_httpd_write_post"
+
+  for entry in "${MANAGED[@]}"; do
+    IFS='|' read -r src dst mode <<<"$entry"
+    src="${SRC_DIR}/${src}"
+    if [[ ! -f "$src" ]]; then
+      echo "ERROR missing in repo: $src" >&2
+      return 1
+    fi
+    # The DA hook must be owned by diradmin; ownership is best-effort so this stays
+    # runnable in a test sandbox where that user does not exist.
+    if [[ "$dst" == *"/user_httpd_write_post/"* ]]; then
+      install -m "$mode" "$src" "$dst"
+      chown "$HOOK_OWNER" "$dst" 2>/dev/null \
+        || echo "WARN could not chown $dst to $HOOK_OWNER"
+    else
+      install -m "$mode" "$src" "$dst"
+    fi
+    echo "installed $dst (mode $mode)"
+  done
+
+  if [[ ! -f "${ETC_DIR}/vhost-listen.conf" ]]; then
+    install -m 600 "${SRC_DIR}/vhost-listen.conf.example" \
+      "${ETC_DIR}/vhost-listen.conf"
+    echo "created ${ETC_DIR}/vhost-listen.conf from example -- EDIT IT:"
+    echo "  set EXPECTED_PUBLIC_IP and a real HEALTH_ALERT_TO"
+  else
+    echo "kept existing ${ETC_DIR}/vhost-listen.conf (host-specific; not overwritten)"
+  fi
+
+  if command -v systemctl >/dev/null 2>&1; then
+    systemctl daemon-reload || true
+    systemctl enable da-vhost-listen-boot.service || true
+  fi
+
+  echo
+  verify
+}
+
+case "$MODE" in
+  verify) verify ;;
+  install) do_install ;;
+esac


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

You're right that merging changes nothing here — this repo has no deploy step, so the host keeps running whatever was last installed by hand. That has already bitten twice in the last hour:

- **#103** changed the reconciler's invariant log wording
- **#104** made it reject placeholder alert addresses

Both merged; neither reached the host. Nothing anywhere reported the mismatch. That is the same class of silent divergence between intent and reality that caused the original catch-all outage — and it undercuts the whole point of the guardrails, because a merged fix that never lands is indistinguishable from no fix.

The README already documented the manual `install -m 755 ...` sequence, but a multi-step copy-paste that must be remembered after every merge is exactly the kind of step that gets skipped.

## What this adds

[`install_da_vhost_listen.sh`](scripts/directadmin/install_da_vhost_listen.sh) with two modes:

```bash
cd /root/wbat-terraform && git pull
./scripts/directadmin/install_da_vhost_listen.sh --verify        # read-only drift report
sudo ./scripts/directadmin/install_da_vhost_listen.sh --install  # install + re-verify
```

- **`--verify`** SHA-256 compares every installed file against the checkout and reports `ok` / `STALE` / `MISSING`, exiting non-zero on any drift. This gives "did this merge actually reach production?" a definite answer instead of a guess.
- **`--install`** is idempotent: installs all five managed files with correct modes, `chown`s the DA hook to `diradmin:diradmin`, enables the boot unit, then re-verifies.

Two deliberate design choices:

- **The runtime conf is presence-checked, not content-compared**, and `--install` never overwrites it. `/etc/da-vhost-listen/vhost-listen.conf` holds host-specific `EXPECTED_PUBLIC_IP` and `HEALTH_ALERT_TO` values, so comparing it against the committed example would report permanent false drift — and clobbering it would wipe the alert address, which is precisely the fix #104 was about.
- **Paths are environment-overridable** so the script is testable without root, which is how the scenarios below were exercised.

## Verification

Sandbox run with overridden paths:

| Scenario | Result |
|---|---|
| `--verify` before any install | all `MISSING`, **exit 1** |
| `--install` | all five installed, conf created from example, **PASS** |
| Edited host conf, then re-install | conf **preserved untouched** |
| Locally modified installed script | reported `STALE`, **exit 1** |
| Re-install after drift | repaired, **PASS** |

The `STALE` case is the exact failure you just hit, now detectable in one command.

CI-equivalent gates pass: `bash -n`, `shellcheck -S error -x -e SC1091`, and the offline fixture detector proofs.

## Note on the host

The box is currently running the pre-#103 reconciler. After merging:

```bash
cd /root/wbat-terraform && git pull
sudo ./scripts/directadmin/install_da_vhost_listen.sh --install
```

Worth running `--verify` on `server2` as well, since it was never confirmed in sync.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9f56-a7f8-7855-8a9d-05a6fedbcfe7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9f56-a7f8-7855-8a9d-05a6fedbcfe7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

