### PR TITLE
chore(github): manage website repos in Terraform

### DIFF
--- a/github/imports.tf
+++ b/github/imports.tf
@@ -73,3 +73,32 @@ import {
   to = module.repos.module.terraform_module_example.github_branch_default.this
   id = "terraform_module_example"
 }
+
+# --- Website / shortener repos (direct resources in repos/*.tf) ---
+
+import {
+  to = module.repos.github_repository.wbat-website
+  id = "wbat-website"
+}
+import {
+  to = module.repos.github_branch_default.wbat-website-main
+  id = "wbat-website"
+}
+
+import {
+  to = module.repos.github_repository.lmgt-website
+  id = "lmgt-website"
+}
+import {
+  to = module.repos.github_branch_default.lmgt-website-main
+  id = "lmgt-website"
+}
+
+import {
+  to = module.repos.github_repository.ysn-tsn-website
+  id = "ysn-tsn-website"
+}
+import {
+  to = module.repos.github_branch_default.ysn-tsn-website-main
+  id = "ysn-tsn-website"
+}

--- a/github/repos/lmgt-website.tf
+++ b/github/repos/lmgt-website.tf
@@ -1,0 +1,32 @@
+# TellersTechOrg/lmgt-website — lmgt.com gag site (imported; pre-existing repo).
+# lmgt.org awards vanity stays with tellerstech-website.
+# Branch protection is not managed here (private repo on free plan → 403).
+# Import blocks live in ../imports.tf (root module).
+
+resource "github_repository" "lmgt-website" {
+  provider = github.tellerstechorg
+
+  name         = "lmgt-website"
+  description  = "lmgt.com gag site (lmgt.org stays on tellerstech.com/awards)"
+  homepage_url = "https://www.lmgt.com/"
+  visibility   = "private"
+
+  has_issues    = true
+  has_wiki      = false
+  has_projects  = true
+  has_downloads = false
+
+  delete_branch_on_merge = true
+
+  allow_merge_commit  = true
+  allow_squash_merge  = true
+  allow_rebase_merge  = true
+  allow_auto_merge    = false
+  allow_update_branch = true
+}
+
+resource "github_branch_default" "lmgt-website-main" {
+  provider   = github.tellerstechorg
+  repository = github_repository.lmgt-website.name
+  branch     = "main"
+}

--- a/github/repos/wbat-website.tf
+++ b/github/repos/wbat-website.tf
@@ -1,0 +1,29 @@
+# wbat/wbat-website — marketing site for wbat.net (imported; pre-existing repo).
+# Branch protection is not managed here: private repos on the current GitHub plan
+# return 403 from the branch protection / rulesets API (requires GitHub Pro or
+# a public repo). Import blocks live in ../imports.tf (root module).
+
+resource "github_repository" "wbat-website" {
+  name         = "wbat-website"
+  description  = "WBAT.net website"
+  homepage_url = "https://www.wbat.net/"
+  visibility   = "private"
+
+  has_issues    = true
+  has_wiki      = false
+  has_projects  = true
+  has_downloads = false
+
+  delete_branch_on_merge = true
+
+  allow_merge_commit  = true
+  allow_squash_merge  = true
+  allow_rebase_merge  = true
+  allow_auto_merge    = false
+  allow_update_branch = true
+}
+
+resource "github_branch_default" "wbat-website-main" {
+  repository = github_repository.wbat-website.name
+  branch     = "main"
+}

--- a/github/repos/ysn-tsn-website.tf
+++ b/github/repos/ysn-tsn-website.tf
@@ -1,0 +1,31 @@
+# TellersTechOrg/ysn-tsn-website — ysn.io + tsn.io shorteners (imported).
+# Branch protection is not managed here (private repo on free plan → 403).
+# Import blocks live in ../imports.tf (root module).
+
+resource "github_repository" "ysn-tsn-website" {
+  provider = github.tellerstechorg
+
+  name         = "ysn-tsn-website"
+  description  = "ysn.io + tsn.io link shorteners (one codebase, two vhosts)"
+  homepage_url = "https://tsn.io/"
+  visibility   = "private"
+
+  has_issues    = true
+  has_wiki      = false
+  has_projects  = true
+  has_downloads = false
+
+  delete_branch_on_merge = true
+
+  allow_merge_commit  = true
+  allow_squash_merge  = true
+  allow_rebase_merge  = true
+  allow_auto_merge    = false
+  allow_update_branch = true
+}
+
+resource "github_branch_default" "ysn-tsn-website-main" {
+  provider   = github.tellerstechorg
+  repository = github_repository.ysn-tsn-website.name
+  branch     = "main"
+}


### PR DESCRIPTION
## Summary
- Manage in `wbat-terraform-github`:
  - `wbat/wbat-website`
  - `TellersTechOrg/lmgt-website`
  - `TellersTechOrg/ysn-tsn-website`
- One-time `import` blocks in `github/imports.tf` (remove after apply)
- **Branch protection / rulesets:** not managed — both orgs are on free plan; private repos return 403 (need GitHub Pro or public repos). Same limitation as `tellerstech-website`.

## Apply notes
After merge, HCP apply for `wbat-terraform-github` should import then converge (enables `delete_branch_on_merge` + `allow_update_branch` + homepage URLs).

## Test plan
- [ ] CI Format + Validate (github) green
- [ ] TFC plan shows imports + small in-place updates (no destroy)
- [ ] After apply, remove the new import blocks in a follow-up


Made with [Cursor](https://cursor.com)