### PR TITLE
chore(github): drop website branch protection on free plan

### DIFF
--- a/github/repos/lmgt-website.tf
+++ b/github/repos/lmgt-website.tf
@@ -1,8 +1,6 @@
 # TellersTechOrg/lmgt-website — lmgt.com gag site (imported; pre-existing repo).
 # lmgt.org awards vanity stays with tellerstech-website.
-# Branch protection is managed below. Private repos need GitHub Team (or public
-# visibility) for the protection API; free-plan orgs return 403 until upgraded.
-# One-time imports removed after apply. No PR CI — status checks omitted.
+# Branch protection is not managed here (private repo on free plan → 403).
 
 resource "github_repository" "lmgt-website" {
   provider = github.tellerstechorg
@@ -30,19 +28,4 @@ resource "github_branch_default" "lmgt-website-main" {
   provider   = github.tellerstechorg
   repository = github_repository.lmgt-website.name
   branch     = "main"
-}
-
-resource "github_branch_protection" "lmgt-website-main" {
-  provider = github.tellerstechorg
-
-  repository_id  = github_repository.lmgt-website.node_id
-  pattern        = "main"
-  enforce_admins = false
-
-  require_conversation_resolution = true
-
-  required_pull_request_reviews {
-    dismiss_stale_reviews           = true
-    required_approving_review_count = 0
-  }
 }

--- a/github/repos/modules/repository/variables.tf
+++ b/github/repos/modules/repository/variables.tf
@@ -46,9 +46,11 @@ variable "has_projects" {
 }
 
 variable "has_downloads" {
-  description = "Enable repository downloads."
+  # GitHub deprecated Downloads; the API commonly reports false even when TF
+  # requests true, which produces perpetual no-op/drift updates on apply.
+  description = "Enable repository downloads (deprecated on GitHub; prefer false)."
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "vulnerability_alerts" {

--- a/github/repos/tellerstech-website.tf
+++ b/github/repos/tellerstech-website.tf
@@ -1,8 +1,6 @@
 # TellersTechOrg/tellerstech-website — WordPress site files (imported; pre-existing repo).
-# Branch protection is managed below. Private repos need GitHub Team (or public
-# visibility) for the protection API; free-plan orgs return 403 until upgraded.
-# One-time imports removed after apply. PR CI is path-filtered (PHP / OCB / e2e),
-# so required_status_checks are omitted to avoid blocking unrelated PRs.
+# Branch protection is not managed here: private repos on the free GitHub plan
+# return 403 from the branch protection API (needs Team or a public repo).
 
 resource "github_repository" "tellerstech-website" {
   provider = github.tellerstechorg
@@ -14,7 +12,7 @@ resource "github_repository" "tellerstech-website" {
   has_issues    = true
   has_wiki      = false
   has_projects  = true
-  has_downloads = true
+  has_downloads = false
 
   delete_branch_on_merge = true
 
@@ -29,19 +27,4 @@ resource "github_branch_default" "tellerstech-website-main" {
   provider   = github.tellerstechorg
   repository = github_repository.tellerstech-website.name
   branch     = "main"
-}
-
-resource "github_branch_protection" "tellerstech-website-main" {
-  provider = github.tellerstechorg
-
-  repository_id  = github_repository.tellerstech-website.node_id
-  pattern        = "main"
-  enforce_admins = false
-
-  require_conversation_resolution = true
-
-  required_pull_request_reviews {
-    dismiss_stale_reviews           = true
-    required_approving_review_count = 0
-  }
 }

--- a/github/repos/wbat-website.tf
+++ b/github/repos/wbat-website.tf
@@ -1,7 +1,6 @@
 # wbat/wbat-website — marketing site for wbat.net (imported; pre-existing repo).
-# Branch protection is managed below. Private repos need GitHub Team (or public
-# visibility) for the protection API; free-plan orgs return 403 until upgraded.
-# One-time imports removed after apply.
+# Branch protection is not managed here: private repos on the free GitHub plan
+# return 403 from the protection / rulesets API (needs Team or a public repo).
 
 resource "github_repository" "wbat-website" {
   name         = "wbat-website"
@@ -26,22 +25,4 @@ resource "github_repository" "wbat-website" {
 resource "github_branch_default" "wbat-website-main" {
   repository = github_repository.wbat-website.name
   branch     = "main"
-}
-
-resource "github_branch_protection" "wbat-website-main" {
-  repository_id  = github_repository.wbat-website.node_id
-  pattern        = "main"
-  enforce_admins = false
-
-  require_conversation_resolution = true
-
-  required_pull_request_reviews {
-    dismiss_stale_reviews           = true
-    required_approving_review_count = 0
-  }
-
-  required_status_checks {
-    contexts = ["PHP lint & smoke"]
-    strict   = true
-  }
 }

--- a/github/repos/ysn-tsn-website.tf
+++ b/github/repos/ysn-tsn-website.tf
@@ -1,7 +1,5 @@
 # TellersTechOrg/ysn-tsn-website — ysn.io + tsn.io shorteners (imported).
-# Branch protection is managed below. Private repos need GitHub Team (or public
-# visibility) for the protection API; free-plan orgs return 403 until upgraded.
-# One-time imports removed after apply. No PR CI — status checks omitted.
+# Branch protection is not managed here (private repo on free plan → 403).
 
 resource "github_repository" "ysn-tsn-website" {
   provider = github.tellerstechorg
@@ -29,19 +27,4 @@ resource "github_branch_default" "ysn-tsn-website-main" {
   provider   = github.tellerstechorg
   repository = github_repository.ysn-tsn-website.name
   branch     = "main"
-}
-
-resource "github_branch_protection" "ysn-tsn-website-main" {
-  provider = github.tellerstechorg
-
-  repository_id  = github_repository.ysn-tsn-website.node_id
-  pattern        = "main"
-  enforce_admins = false
-
-  require_conversation_resolution = true
-
-  required_pull_request_reviews {
-    dismiss_stale_reviews           = true
-    required_approving_review_count = 0
-  }
 }


### PR DESCRIPTION
## Summary
- Remove `github_branch_protection` from `wbat-website`, `lmgt-website`, `ysn-tsn-website`, and `tellerstech-website` (free-plan private repos → API 403; #107 apply errored).
- Default module `has_downloads` to `false` (and align tellerstech-website) so applies stop fighting GitHub’s deprecated Downloads field.

## Test plan
- [ ] CI fmt + validate green
- [ ] HCP `wbat-terraform-github` plan: 0 to add for branch protection; no 403s
- [ ] Confirm apply succeeds after merge

Made with [Cursor](https://cursor.com)