### PR TITLE
docs(github): branch protection Team plan note

### DIFF
--- a/github/README.md
+++ b/github/README.md
@@ -1,0 +1,14 @@
+# GitHub workspace (`wbat/wbat-terraform` → `github/`)
+
+Terraform manages WBAT org repositories and shared settings.
+
+## Branch protection (Team plan required)
+
+Private repositories on GitHub Free/Pro **cannot** use organization-level branch protection rules via the API (403 on apply). Terraform resources for `github_branch_protection` were removed in [#108](https://github.com/wbat/wbat-terraform/pull/108) after apply failed.
+
+Until the org upgrades to **GitHub Team** (or repos are public):
+
+- Enforce `main` protection manually in the GitHub UI for critical repos, or
+- Re-introduce `github_branch_protection` resources in `repos/modules/repository/` once the plan supports it.
+
+Imported website repos (`wbat-website`, `lmgt-website`, `ysn-tsn-website`, `tellerstech-website`) still receive `delete_branch_on_merge`, `allow_update_branch`, and homepage URLs from Terraform.

--- a/github/README.md
+++ b/github/README.md
@@ -9,6 +9,12 @@ Private repositories on GitHub Free/Pro **cannot** use organization-level branch
 Until the org upgrades to **GitHub Team** (or repos are public):
 
 - Enforce `main` protection manually in the GitHub UI for critical repos, or
-- Re-introduce `github_branch_protection` resources in `repos/modules/repository/` once the plan supports it.
+- Re-introduce `github_branch_protection` on **each standalone website resource** once the plan supports it:
+  - `repos/wbat-website.tf`
+  - `repos/lmgt-website.tf`
+  - `repos/ysn-tsn-website.tf`
+  - `repos/tellerstech-website.tf`
+
+`repos/modules/repository/main.tf` already defines `github_branch_protection.this` for repos created through that module (for example `wbat-terraform`, `iTerm2-Git-Status-Bar`). The four imported website repos are **not** module instances — restoring their protection means adding `github_branch_protection` resources to those individual files (or migrating the repos into the module first). Following the module path alone would leave the website repos unprotected.
 
 Imported website repos (`wbat-website`, `lmgt-website`, `ysn-tsn-website`, `tellerstech-website`) still receive `delete_branch_on_merge`, `allow_update_branch`, and homepage URLs from Terraform.


### PR DESCRIPTION
## Summary
- Add `github/README.md` explaining the GitHub Free/Pro branch protection 403 and manual workaround until Team upgrade.

## Test plan
- [x] Docs only


Made with [Cursor](https://cursor.com)